### PR TITLE
Implement _add_compatibility.

### DIFF
--- a/tests/test_clf_cbf.py
+++ b/tests/test_clf_cbf.py
@@ -3,6 +3,7 @@ import compatible_clf_cbf.clf_cbf as mut
 import numpy as np
 import pytest  # noqa
 
+import pydrake.solvers as solvers
 import pydrake.symbolic as sym
 
 import compatible_clf_cbf.utils as utils
@@ -46,7 +47,17 @@ class TestClfCbf(object):
             with_clf=True,
             use_y_squared=True,
         )
+
+        def check_members(cls: mut.CompatibleClfCbf):
+            assert cls.y_poly.shape == cls.y.shape
+            for y_poly_i, y_i in zip(cls.y_poly.flat, cls.y.flat):
+                assert y_poly_i.EqualTo(sym.Polynomial(y_i))
+            assert cls.y_squared_poly.shape == cls.y.shape
+            for y_squared_poly_i, y_i in zip(cls.y_squared_poly.flat, cls.y.flat):
+                assert y_squared_poly_i.EqualTo(sym.Polynomial(y_i**2))
+
         assert dut.y.shape == (len(self.unsafe_regions) + 1,)
+        check_members(dut)
 
         # Now construct with with_clf=False
         dut = mut.CompatibleClfCbf(
@@ -60,6 +71,7 @@ class TestClfCbf(object):
             use_y_squared=True,
         )
         assert dut.y.shape == (len(self.unsafe_regions),)
+        check_members(dut)
 
     def test_calc_xi_Lambda_w_clf(self):
         """
@@ -141,3 +153,75 @@ class TestClfCbf(object):
         lambda_mat_expected = np.empty((2, self.nu), dtype=object)
         lambda_mat_expected = -dbdx @ self.g
         utils.check_polynomial_arrays_equal(lambda_mat, lambda_mat_expected, 1e-8)
+
+    def test_add_compatibility_w_clf_y_squared(self):
+        """
+        Test _add_compatibility with CLF and use_y_squared=True
+        """
+        dut = mut.CompatibleClfCbf(
+            f=self.f,
+            g=self.g,
+            x=self.x,
+            unsafe_regions=self.unsafe_regions,
+            Au=None,
+            bu=None,
+            with_clf=True,
+            use_y_squared=True,
+        )
+        prog = solvers.MathematicalProgram()
+        prog.AddIndeterminates(dut.xy_set)
+
+        V = prog.NewFreePolynomial(dut.x_set, deg=2)
+        V = sym.Polynomial(dut.x[0] ** 2 + 4 * dut.x[1] ** 2)
+        b = np.array(
+            [
+                sym.Polynomial(1 - dut.x[0] ** 2 - dut.x[1] ** 2),
+                sym.Polynomial(2 - dut.x[0] ** 2 - dut.x[2] ** 2),
+            ]
+        )
+        kappa_V = 0.01
+        kappa_b = np.array([0.02, 0.03])
+
+        # Set up Lagrangians.
+        lambda_y_lagrangian = np.array(
+            [prog.NewFreePolynomial(dut.xy_set, deg=2) for _ in range(dut.nu)]
+        )
+        xi_y_lagrangian = prog.NewFreePolynomial(dut.xy_set, deg=2)
+        y_lagrangian = None
+        rho_minus_V_lagrangian, _ = prog.NewSosPolynomial(dut.xy_set, degree=2)
+        b_plus_eps_lagrangian = np.array(
+            [
+                prog.NewSosPolynomial(dut.xy_set, degree=2)[0]
+                for _ in range(len(dut.unsafe_regions))
+            ]
+        )
+        lagrangians = mut.CompatibleLagrangians(
+            lambda_y=lambda_y_lagrangian,
+            xi_y=xi_y_lagrangian,
+            y=y_lagrangian,
+            rho_minus_V=rho_minus_V_lagrangian,
+            b_plus_eps=b_plus_eps_lagrangian,
+        )
+
+        rho = 0.1
+        barrier_eps = np.array([0.01, 0.02])
+        poly = dut._add_compatibility(
+            prog=prog,
+            V=V,
+            b=b,
+            kappa_V=kappa_V,
+            kappa_b=kappa_b,
+            lagrangians=lagrangians,
+            rho=rho,
+            barrier_eps=barrier_eps,
+        )
+        (xi, lambda_mat) = dut._calc_xi_Lambda(
+            V=V, b=b, kappa_V=kappa_V, kappa_b=kappa_b
+        )
+        poly_expected = (
+            lagrangians.lambda_y.dot(lambda_mat.T @ dut.y_squared_poly)
+            + lagrangians.xi_y * (xi.dot(dut.y_squared_poly) + 1)
+            + lagrangians.rho_minus_V * (rho - V)
+            + lagrangians.b_plus_eps.dot(b + barrier_eps)
+        )
+        assert poly.CoefficientsAlmostEqual(poly_expected, tolerance=1e-5)


### PR DESCRIPTION
Add the p-satz condition to prove the emptiness of a set, which certifies the compatibility between CLF/CBFs according to Farkas lemma.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hongkai-dai/compatible_clf_cbf/8)
<!-- Reviewable:end -->
