### PR TITLE
Add _add_ellipsoid_in_compatible_region_constraint.

### DIFF
--- a/compatible_clf_cbf/utils.py
+++ b/compatible_clf_cbf/utils.py
@@ -193,7 +193,7 @@ def to_lower_triangular_columns(mat: np.ndarray) -> np.ndarray:
     ret = np.empty(int((dim + 1) * dim / 2), dtype=mat.dtype)
     count = 0
     for col in range(dim):
-        ret[count: count + dim - col] = mat[col:, col]
+        ret[count : count + dim - col] = mat[col:, col]  # noqa
         count += dim - col
     return ret
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 # Read the contents of requirements file
-with open('requirements.txt') as f:
+with open("requirements.txt") as f:
     requirements = f.read().splitlines()
 
 setup(


### PR DESCRIPTION
Add the constraint that the compatible region should contain a given ellipsoid when searching for CLF/CBF.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hongkai-dai/compatible_clf_cbf/27)
<!-- Reviewable:end -->
