### PR TITLE
Add state equality constraint to ellipsoid containment.

### DIFF
--- a/compatible_clf_cbf/clf_cbf.py
+++ b/compatible_clf_cbf/clf_cbf.py
@@ -950,7 +950,7 @@ class CompatibleClfCbf:
             V_contain_lagrangian.add_constraint(
                 prog,
                 inner_ineq_poly=np.array([ellipsoid]),
-                inner_eq_poly=np.array([]),
+                inner_eq_poly=self.state_eq_constraints,
                 outer_poly=V - rho,
             )
         b_contain_lagrangians = [
@@ -962,7 +962,7 @@ class CompatibleClfCbf:
             b_contain_lagrangians[i].add_constraint(
                 prog,
                 inner_ineq_poly=np.array([ellipsoid]),
-                inner_eq_poly=np.array([]),
+                inner_eq_poly=self.state_eq_constraints,
                 outer_poly=-b[i],
             )
 
@@ -1028,8 +1028,15 @@ class CompatibleClfCbf:
         )
         if V is not None:
             V_degree = V.TotalDegree()
+            inner_eq_lagrangian_degree = (
+                []
+                if self.state_eq_constraints is None
+                else [
+                    V_degree - poly.TotalDegree() for poly in self.state_eq_constraints
+                ]
+            )
             ellipsoid_in_V_lagrangian_degree = ContainmentLagrangianDegree(
-                inner_ineq=[V_degree - 2], inner_eq=[], outer=-1
+                inner_ineq=[V_degree - 2], inner_eq=inner_eq_lagrangian_degree, outer=-1
             )
             ellipsoid_in_V_lagrangian = (
                 ellipsoid_in_V_lagrangian_degree.construct_lagrangian(prog, self.x_set)
@@ -1038,13 +1045,20 @@ class CompatibleClfCbf:
             ellipsoid_in_V_lagrangian.add_constraint(
                 prog,
                 inner_ineq_poly=np.array([ellipsoid_poly]),
-                inner_eq_poly=np.array([]),
+                inner_eq_poly=self.state_eq_constraints,
                 outer_poly=V - sym.Polynomial({sym.Monomial(): sym.Expression(rho)}),
             )
         for i in range(b.size):
             b_degree = b[i].TotalDegree()
+            inner_eq_lagrangian_degree = (
+                []
+                if self.state_eq_constraints is None
+                else [
+                    b_degree - poly.TotalDegree() for poly in self.state_eq_constraints
+                ]
+            )
             ellipsoid_in_b_lagrangian_degree = ContainmentLagrangianDegree(
-                inner_ineq=[b_degree - 2], inner_eq=[], outer=-1
+                inner_ineq=[b_degree - 2], inner_eq=inner_eq_lagrangian_degree, outer=-1
             )
             ellipsoid_in_b_lagrangian = (
                 ellipsoid_in_b_lagrangian_degree.construct_lagrangian(prog, self.x_set)
@@ -1052,6 +1066,6 @@ class CompatibleClfCbf:
             ellipsoid_in_b_lagrangian.add_constraint(
                 prog,
                 inner_ineq_poly=np.array([ellipsoid_poly]),
-                inner_eq_poly=np.array([]),
+                inner_eq_poly=self.state_eq_constraints,
                 outer_poly=-b[i],
             )

--- a/compatible_clf_cbf/utils.py
+++ b/compatible_clf_cbf/utils.py
@@ -150,14 +150,17 @@ class ContainmentLagrangian:
         self,
         prog,
         inner_ineq_poly: np.ndarray,
-        inner_eq_poly: np.ndarray,
+        inner_eq_poly: Optional[np.ndarray],
         outer_poly: sym.Polynomial,
     ) -> Tuple[sym.Polynomial, np.ndarray]:
-        return prog.AddSosConstraint(
-            -(1 + self.outer) * outer_poly
-            + self.inner_ineq.dot(inner_ineq_poly)
-            + self.inner_eq.dot(inner_eq_poly)
+        sos_condition = -(1 + self.outer) * outer_poly + self.inner_ineq.dot(
+            inner_ineq_poly
         )
+        if inner_eq_poly is None:
+            assert self.inner_eq is None or self.inner_eq.size == 0
+        else:
+            sos_condition += self.inner_eq.dot(inner_eq_poly)
+        return prog.AddSosConstraint(sos_condition)
 
     def get_result(self, result: solvers.MathematicalProgramResult) -> Self:
         return ContainmentLagrangian(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -78,7 +78,7 @@ class TestContainmentLagrangian:
         )
         lagrangians = containment_lagrangian_degree.construct_lagrangian(prog, x_set)
         lagrangians.add_constraint(
-            prog, inner_ineq_poly, inner_eq_poly=np.array([]), outer_poly=outer_poly
+            prog, inner_ineq_poly, inner_eq_poly=None, outer_poly=outer_poly
         )
         result = solvers.Solve(prog)
         assert not result.is_success()


### PR DESCRIPTION
When we constrain that the compatible region contains the inner ellipsoid, also impose the state equality constraints.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hongkai-dai/compatible_clf_cbf/37)
<!-- Reviewable:end -->
