### PR TITLE
Fix rho to one in the CLF sublevel set.

### DIFF
--- a/examples/linear_toy/linear_toy_demo.py
+++ b/examples/linear_toy/linear_toy_demo.py
@@ -37,7 +37,7 @@ def search_compatible_lagrangians(
         state_eq_constraints=None,
     )
     prog, lagrangians = dut.construct_search_compatible_lagrangians(
-        V, b, kappa_V, kappa_b, lagrangian_degrees, rho=None, barrier_eps=None
+        V, b, kappa_V, kappa_b, lagrangian_degrees, barrier_eps=None, local_clf=False
     )
 
     result = pydrake.solvers.Solve(prog)

--- a/examples/nonlinear_toy/wo_input_limits_demo.py
+++ b/examples/nonlinear_toy/wo_input_limits_demo.py
@@ -23,7 +23,7 @@ def main(use_y_squared: bool):
         with_clf=True,
         use_y_squared=use_y_squared,
     )
-    V_init = sym.Polynomial(x[0] ** 2 + x[1] ** 2)
+    V_init = sym.Polynomial(x[0] ** 2 + x[1] ** 2) / 0.01
     b_init = np.array([sym.Polynomial(0.001 - x[0] ** 2 - x[1] ** 2)])
     kappa_V = 1e-3
     kappa_b = np.array([kappa_V])
@@ -41,13 +41,12 @@ def main(use_y_squared: bool):
         b_plus_eps=[clf_cbf.CompatibleLagrangianDegrees.Degree(x=2, y=0)],
         state_eq_constraints=None,
     )
-    rho = 0.01
     barrier_eps = np.array([0.0001])
     (
         compatible_prog,
         compatible_lagrangians,
     ) = compatible.construct_search_compatible_lagrangians(
-        V_init, b_init, kappa_V, kappa_b, lagrangian_degrees, rho, barrier_eps
+        V_init, b_init, kappa_V, kappa_b, lagrangian_degrees, barrier_eps
     )
     compatible_result = solvers.Solve(compatible_prog)
     assert compatible_result.is_success()

--- a/examples/nonlinear_toy/wo_input_limits_trigpoly_demo.py
+++ b/examples/nonlinear_toy/wo_input_limits_trigpoly_demo.py
@@ -27,9 +27,8 @@ def main():
         use_y_squared=use_y_squared,
         state_eq_constraints=state_eq_constraints,
     )
-    V_init = sym.Polynomial(x[0] ** 2 + x[1] ** 2 + x[2] ** 2)
+    V_init = sym.Polynomial(x[0] ** 2 + x[1] ** 2 + x[2] ** 2) / 0.1
     b_init = np.array([sym.Polynomial(0.1 - x[0] ** 2 - x[1] ** 2 - x[2] ** 2)])
-    rho_init = 0.1
 
     compatible_lagrangian_degrees = clf_cbf.CompatibleLagrangianDegrees(
         lambda_y=[clf_cbf.CompatibleLagrangianDegrees.Degree(x=2, y=0)],
@@ -54,10 +53,9 @@ def main():
     cbf_degrees = [2]
     max_iter = 5
 
-    V, b, rho = compatible.bilinear_alternation(
+    V, b = compatible.bilinear_alternation(
         V_init,
         b_init,
-        rho_init,
         compatible_lagrangian_degrees,
         unsafe_region_lagrangian_degrees,
         kappa_V,
@@ -71,7 +69,6 @@ def main():
         find_inner_ellipsoid_max_iter=1,
     )
     print(f"V={V}")
-    print(f"rho={rho}")
     print(f"b={b}")
 
 


### PR DESCRIPTION
By removing this variable, we impose some implicit normalization on the CLF.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hongkai-dai/compatible_clf_cbf/45)
<!-- Reviewable:end -->
