### PR TITLE
The safety constraint for CBF handle multiple CBFs.

### DIFF
--- a/compatible_clf_cbf/cbf.py
+++ b/compatible_clf_cbf/cbf.py
@@ -361,19 +361,19 @@ class ControlBarrier:
         """
         Adds the constraint that the 0-super level set of the barrier function
         is in the safe region {x | pᵢ(x) <= 0}.
-        −(1+ϕ₀(x))pᵢ(x) − ϕ₁(x)h(x) is sos.
+        −(1+ϕ₀(x))pᵢ(x) − ∑ᵢψᵢ(x)h(x) is sos.
 
         Note it doesn't add the constraints
-        ϕ₀(x) is sos
-        ϕ₁(x) is sos.
+        ϕ₀(x) is sos, ψᵢ(x) is sos.
 
         Args:
           safe_region_index: pᵢ(x) = self.safety_set.within[within_index]
         """
         assert self.within_set is not None
+        assert lagrangians.cbf.size == 1
         poly = (
             -(1 + lagrangians.safe_region) * self.within_set.l[within_index]
-            - lagrangians.cbf * h
+            - lagrangians.cbf[0] * h
         )
         if self.state_eq_constraints is not None:
             assert lagrangians.state_eq_constraints is not None
@@ -395,12 +395,12 @@ class ControlBarrier:
         polynomials p(x), we want to certify that the set {x|p(x)≤0, h(x)≥0}
         is empty.
         The emptiness of the set can be certified by the constraint
-        -(1+ϕ₀(x))h(x) +∑ⱼϕⱼ(x)pⱼ(x) is sos
-        ϕ₀(x), ϕⱼ(x) are sos.
+        -∑ᵢϕᵢ(x))*hᵢ(x) +∑ⱼψⱼ(x)pⱼ(x)-1 is sos
+        ϕᵢ(x), ψⱼ(x) are sos.
 
         Note that this function only adds the constraint
-        -(1+ϕ₀(x))*hᵢ(x) +∑ⱼϕⱼ(x)pⱼ(x) is sos
-        It doesn't add the constraint ϕ₀(x), ϕⱼ(x) are sos.
+        -(1+ϕᵢ,₀(x))*hᵢ(x) +∑ⱼϕᵢ,ⱼ(x)pⱼ(x) is sos
+        It doesn't add the constraint ϕᵢ,₀(x), ϕᵢ,ⱼ(x) are sos.
 
         Args:
           h: a polynomial, h is the barrier function for the
@@ -409,7 +409,8 @@ class ControlBarrier:
         Returns:
           poly: poly is the polynomial -(1+ϕ₀(x))hᵢ(x) + ∑ⱼϕⱼ(x)pⱼ(x)
         """
-        poly = -(1 + lagrangians.cbf) * h + lagrangians.unsafe_region.dot(
+        assert lagrangians.cbf.size == 1
+        poly = -(1 + lagrangians.cbf[0]) * h + lagrangians.unsafe_region.dot(
             self.exclude_sets[exclude_set_index].l
         )
         if self.state_eq_constraints is not None:

--- a/examples/linear_toy/linear_toy_demo.py
+++ b/examples/linear_toy/linear_toy_demo.py
@@ -57,13 +57,13 @@ def search_barrier_safe_lagrangians(
         clf_cbf.SafetySetLagrangianDegrees(
             exclude=[
                 clf_cbf.ExcludeRegionLagrangianDegrees(
-                    cbf=2, unsafe_region=[2], state_eq_constraints=None
+                    cbf=[2], unsafe_region=[2], state_eq_constraints=None
                 )
             ],
             within=[],
         )
     ]
-    lagrangians = dut.certify_cbf_safety_set(h[0], lagrangian_degrees[0])
+    lagrangians = dut.certify_cbf_safety_set(h, lagrangian_degrees[0])
     assert lagrangians is not None
     return [lagrangians]
 

--- a/examples/linear_toy/linear_toy_w_input_limits_demo.py
+++ b/examples/linear_toy/linear_toy_w_input_limits_demo.py
@@ -58,13 +58,13 @@ def search_barrier_safe_lagrangians(
         clf_cbf.SafetySetLagrangianDegrees(
             exclude=[
                 clf_cbf.ExcludeRegionLagrangianDegrees(
-                    cbf=2, unsafe_region=[2], state_eq_constraints=None
+                    cbf=[2], unsafe_region=[2], state_eq_constraints=None
                 )
             ],
             within=[],
         )
     ]
-    lagrangians = dut.certify_cbf_safety_set(h[0], lagrangian_degrees[0])
+    lagrangians = dut.certify_cbf_safety_set(h, lagrangian_degrees[0])
     assert lagrangians is not None
     return [lagrangians]
 

--- a/examples/nonlinear_toy/demo.py
+++ b/examples/nonlinear_toy/demo.py
@@ -71,7 +71,7 @@ def main(use_y_squared: bool, with_u_bound: bool):
         clf_cbf.SafetySetLagrangianDegrees(
             exclude=[
                 clf_cbf.ExcludeRegionLagrangianDegrees(
-                    cbf=0, unsafe_region=[0], state_eq_constraints=None
+                    cbf=[0], unsafe_region=[0], state_eq_constraints=None
                 )
             ],
             within=[],
@@ -80,7 +80,7 @@ def main(use_y_squared: bool, with_u_bound: bool):
 
     safety_sets_lagrangians = [
         compatible.certify_cbf_safety_set(
-            cbf=h_init[0],
+            h=h_init,
             lagrangian_degrees=safety_sets_lagrangian_degrees[0],
             solver_options=None,
         )

--- a/examples/nonlinear_toy/demo_trigpoly.py
+++ b/examples/nonlinear_toy/demo_trigpoly.py
@@ -153,16 +153,15 @@ def search(unit_test_flag: bool = False):
         h_plus_eps=[clf_cbf.CompatibleLagrangianDegrees.Degree(x=2, y=2)],
         state_eq_constraints=[clf_cbf.CompatibleLagrangianDegrees.Degree(x=2, y=2)],
     )
-    safety_sets_lagrangian_degrees = [
-        clf_cbf.SafetySetLagrangianDegrees(
-            exclude=[
-                clf_cbf.ExcludeRegionLagrangianDegrees(
-                    cbf=0, unsafe_region=[0], state_eq_constraints=[0]
-                )
-            ],
-            within=[],
-        )
-    ]
+    safety_sets_lagrangian_degrees = clf_cbf.SafetySetLagrangianDegrees(
+        exclude=[
+            clf_cbf.ExcludeRegionLagrangianDegrees(
+                cbf=[0], unsafe_region=[0], state_eq_constraints=[0]
+            )
+        ],
+        within=[],
+    )
+
     kappa_V = 0.1
     kappa_h = np.array([0.1])
     barrier_eps = np.array([0.001])

--- a/examples/nonlinear_toy/synthesize_demo.py
+++ b/examples/nonlinear_toy/synthesize_demo.py
@@ -49,16 +49,15 @@ def main(with_u_bound: bool):
         h_plus_eps=[clf_cbf.CompatibleLagrangianDegrees.Degree(x=2, y=2)],
         state_eq_constraints=None,
     )
-    safety_sets_lagrangian_degrees = [
-        clf_cbf.SafetySetLagrangianDegrees(
-            exclude=[
-                clf_cbf.ExcludeRegionLagrangianDegrees(
-                    cbf=0, unsafe_region=[0], state_eq_constraints=None
-                )
-            ],
-            within=[],
-        )
-    ]
+    safety_sets_lagrangian_degrees = clf_cbf.SafetySetLagrangianDegrees(
+        exclude=[
+            clf_cbf.ExcludeRegionLagrangianDegrees(
+                cbf=[0], unsafe_region=[0], state_eq_constraints=None
+            )
+        ],
+        within=[],
+    )
+
     x_equilibrium = np.array([0.0, 0.0])
 
     clf_degree = 2

--- a/examples/power_converter/demo.py
+++ b/examples/power_converter/demo.py
@@ -120,17 +120,16 @@ def search(use_y_squared: bool):
         state_eq_constraints=None,
     )
 
-    safety_sets_lagrangian_degrees = [
-        clf_cbf.SafetySetLagrangianDegrees(
-            exclude=[],
-            within=[
-                clf_cbf.WithinRegionLagrangianDegrees(
-                    cbf=0, safe_region=0, state_eq_constraints=None
-                )
-                for _ in range(3)
-            ],
-        )
-    ]
+    safety_sets_lagrangian_degrees = clf_cbf.SafetySetLagrangianDegrees(
+        exclude=[],
+        within=[
+            clf_cbf.WithinRegionLagrangianDegrees(
+                cbf=[0], safe_region=0, state_eq_constraints=None
+            )
+            for _ in range(3)
+        ],
+    )
+
     barrier_eps = np.array([0.0])
     x_equilibrium = np.zeros((3,))
 

--- a/examples/quadrotor2d/demo.py
+++ b/examples/quadrotor2d/demo.py
@@ -75,16 +75,15 @@ def main(use_y_squared: bool, with_u_bound: bool):
         h_plus_eps=[clf_cbf.CompatibleLagrangianDegrees.Degree(x=2, y=2)],
         state_eq_constraints=[clf_cbf.CompatibleLagrangianDegrees.Degree(x=2, y=2)],
     )
-    safety_sets_lagrangian_degrees = [
-        clf_cbf.SafetySetLagrangianDegrees(
-            exclude=[
-                clf_cbf.ExcludeRegionLagrangianDegrees(
-                    cbf=0, unsafe_region=[0], state_eq_constraints=[0]
-                )
-            ],
-            within=[],
-        )
-    ]
+    safety_sets_lagrangian_degrees = clf_cbf.SafetySetLagrangianDegrees(
+        exclude=[
+            clf_cbf.ExcludeRegionLagrangianDegrees(
+                cbf=[0], unsafe_region=[0], state_eq_constraints=[0]
+            )
+        ],
+        within=[],
+    )
+
     barrier_eps = np.array([0.000])
     x_equilibrium = np.zeros((7,))
     compatible_states_options = clf_cbf.CompatibleStatesOptions(

--- a/examples/quadrotor2d/demo_taylor.py
+++ b/examples/quadrotor2d/demo_taylor.py
@@ -89,16 +89,15 @@ def search_clf_cbf(
     )
     barrier_eps = np.array([0.0])
 
-    safety_sets_lagrangian_degrees = [
-        clf_cbf.SafetySetLagrangianDegrees(
-            exclude=[
-                clf_cbf.ExcludeRegionLagrangianDegrees(
-                    cbf=0, unsafe_region=[2], state_eq_constraints=None
-                )
-            ],
-            within=[],
-        )
-    ]
+    safety_sets_lagrangian_degrees = clf_cbf.SafetySetLagrangianDegrees(
+        exclude=[
+            clf_cbf.ExcludeRegionLagrangianDegrees(
+                cbf=[0], unsafe_region=[2], state_eq_constraints=None
+            )
+        ],
+        within=[],
+    )
+
     solver_options = solvers.SolverOptions()
     solver_options.SetOption(solvers.CommonSolverOption.kPrintToConsole, True)
     if grow_heuristics == GrowHeuristics.kInnerEllipsoid:

--- a/examples/single_integrator/wo_input_limit_demo.py
+++ b/examples/single_integrator/wo_input_limit_demo.py
@@ -112,7 +112,7 @@ def certify_clf_cbf_separately(
         clf_cbf.SafetySetLagrangianDegrees(
             exclude=[
                 clf_cbf.ExcludeRegionLagrangianDegrees(
-                    cbf=0, unsafe_region=[0], state_eq_constraints=None
+                    cbf=[0], unsafe_region=[0], state_eq_constraints=None
                 )
             ],
             within=[],

--- a/tests/test_cbf.py
+++ b/tests/test_cbf.py
@@ -82,7 +82,7 @@ class TestCbf:
         prog.AddIndeterminates(dut.x_set)
 
         lagrangians = ExcludeRegionLagrangians(
-            cbf=sym.Polynomial(1 + self.x[0]),
+            cbf=np.array([sym.Polynomial(1 + self.x[0])]),
             unsafe_region=np.array(
                 [sym.Polynomial(2 + self.x[0]), sym.Polynomial(3 - self.x[1])]
             ),
@@ -93,7 +93,7 @@ class TestCbf:
         poly = dut._add_barrier_exclude_constraint(
             prog, exclude_set_index, h, lagrangians
         )
-        poly_expected = -(1 + lagrangians.cbf) * h + lagrangians.unsafe_region.dot(
+        poly_expected = -(1 + lagrangians.cbf[0]) * h + lagrangians.unsafe_region.dot(
             dut.exclude_sets[exclude_set_index].l
         )
         assert poly.CoefficientsAlmostEqual(poly_expected, 1e-8)


### PR DESCRIPTION
Previously each safety set is for one scalar-value CBF. Now we consider the intersection of multiple CBF 0-super-level set as the safe set, and this safe set must be contained in the within_set, and not intersect with the exclude_set.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hongkai-dai/compatible_clf_cbf/71)
<!-- Reviewable:end -->
