### PR TITLE
Implement add_compatibility_w_u_polyhedron function.

### DIFF
--- a/examples/linear_toy/linear_toy_demo.py
+++ b/examples/linear_toy/linear_toy_demo.py
@@ -24,20 +24,15 @@ def search_compatible_lagrangians(
 
     # Search for the
     lagrangian_degrees = clf_cbf.CompatibleLagrangianDegrees(
-        lambda_y=[
-            clf_cbf.CompatibleLagrangianDegrees.Degree(x=2, y=0) for _ in range(dut.nu)
-        ],
-        xi_y=clf_cbf.CompatibleLagrangianDegrees.Degree(x=2, y=0),
+        lambda_y=[clf_cbf.XYDegree(x=2, y=0) for _ in range(dut.nu)],
+        xi_y=clf_cbf.XYDegree(x=2, y=0),
         y=(
             None
             if dut.use_y_squared
-            else [
-                clf_cbf.CompatibleLagrangianDegrees.Degree(x=2, y=0)
-                for _ in range(y_size)
-            ]
+            else [clf_cbf.XYDegree(x=2, y=0) for _ in range(y_size)]
         ),
         rho_minus_V=None,
-        h_plus_eps=None,
+        h_plus_eps=[clf_cbf.XYDegree(x=2, y=0)],
         state_eq_constraints=None,
     )
     prog, lagrangians = dut.construct_search_compatible_lagrangians(

--- a/examples/linear_toy/linear_toy_w_input_limits_demo.py
+++ b/examples/linear_toy/linear_toy_w_input_limits_demo.py
@@ -25,20 +25,15 @@ def search_compatible_lagrangians(
     y_size = dut.y.size
 
     lagrangian_degrees = clf_cbf.CompatibleLagrangianDegrees(
-        lambda_y=[
-            clf_cbf.CompatibleLagrangianDegrees.Degree(x=2, y=0) for _ in range(dut.nu)
-        ],
-        xi_y=clf_cbf.CompatibleLagrangianDegrees.Degree(x=2, y=0),
+        lambda_y=[clf_cbf.XYDegree(x=2, y=0) for _ in range(dut.nu)],
+        xi_y=clf_cbf.XYDegree(x=2, y=0),
         y=(
             None
             if dut.use_y_squared
-            else [
-                clf_cbf.CompatibleLagrangianDegrees.Degree(x=2, y=0)
-                for _ in range(y_size)
-            ]
+            else [clf_cbf.XYDegree(x=2, y=0) for _ in range(y_size)]
         ),
-        rho_minus_V=clf_cbf.CompatibleLagrangianDegrees.Degree(x=2, y=2),
-        h_plus_eps=[clf_cbf.CompatibleLagrangianDegrees.Degree(x=2, y=2)],
+        rho_minus_V=clf_cbf.XYDegree(x=2, y=2),
+        h_plus_eps=[clf_cbf.XYDegree(x=2, y=2)],
         state_eq_constraints=None,
     )
     prog, lagrangians = dut.construct_search_compatible_lagrangians(

--- a/examples/nonlinear_toy/demo.py
+++ b/examples/nonlinear_toy/demo.py
@@ -41,18 +41,15 @@ def main(use_y_squared: bool, with_u_bound: bool):
     kappa_h = np.array([kappa_V])
 
     lagrangian_degrees = clf_cbf.CompatibleLagrangianDegrees(
-        lambda_y=[clf_cbf.CompatibleLagrangianDegrees.Degree(x=3, y=0)],
-        xi_y=clf_cbf.CompatibleLagrangianDegrees.Degree(x=2, y=0),
+        lambda_y=[clf_cbf.XYDegree(x=3, y=0)],
+        xi_y=clf_cbf.XYDegree(x=2, y=0),
         y=(
             None
             if use_y_squared
-            else [
-                clf_cbf.CompatibleLagrangianDegrees.Degree(x=4, y=0)
-                for _ in range(compatible.y.size)
-            ]
+            else [clf_cbf.XYDegree(x=4, y=0) for _ in range(compatible.y.size)]
         ),
-        rho_minus_V=clf_cbf.CompatibleLagrangianDegrees.Degree(x=2, y=2),
-        h_plus_eps=[clf_cbf.CompatibleLagrangianDegrees.Degree(x=2, y=2)],
+        rho_minus_V=clf_cbf.XYDegree(x=2, y=2),
+        h_plus_eps=[clf_cbf.XYDegree(x=2, y=2)],
         state_eq_constraints=None,
     )
     barrier_eps = np.array([0.0001])

--- a/examples/nonlinear_toy/demo_trigpoly.py
+++ b/examples/nonlinear_toy/demo_trigpoly.py
@@ -146,12 +146,12 @@ def search(unit_test_flag: bool = False):
     V_init, h_init = get_clf_cbf_init(x)
 
     compatible_lagrangian_degrees = clf_cbf.CompatibleLagrangianDegrees(
-        lambda_y=[clf_cbf.CompatibleLagrangianDegrees.Degree(x=2, y=0)],
-        xi_y=clf_cbf.CompatibleLagrangianDegrees.Degree(x=2, y=0),
+        lambda_y=[clf_cbf.XYDegree(x=2, y=0)],
+        xi_y=clf_cbf.XYDegree(x=2, y=0),
         y=None,
-        rho_minus_V=clf_cbf.CompatibleLagrangianDegrees.Degree(x=2, y=2),
-        h_plus_eps=[clf_cbf.CompatibleLagrangianDegrees.Degree(x=2, y=2)],
-        state_eq_constraints=[clf_cbf.CompatibleLagrangianDegrees.Degree(x=2, y=2)],
+        rho_minus_V=clf_cbf.XYDegree(x=2, y=2),
+        h_plus_eps=[clf_cbf.XYDegree(x=2, y=2)],
+        state_eq_constraints=[clf_cbf.XYDegree(x=2, y=2)],
     )
     safety_sets_lagrangian_degrees = clf_cbf.SafetySetLagrangianDegrees(
         exclude=[

--- a/examples/nonlinear_toy/synthesize_demo.py
+++ b/examples/nonlinear_toy/synthesize_demo.py
@@ -42,11 +42,11 @@ def main(with_u_bound: bool):
     barrier_eps = np.array([0.0001])
 
     compatible_lagrangian_degrees = clf_cbf.CompatibleLagrangianDegrees(
-        lambda_y=[clf_cbf.CompatibleLagrangianDegrees.Degree(x=3, y=0)],
-        xi_y=clf_cbf.CompatibleLagrangianDegrees.Degree(x=2, y=0),
+        lambda_y=[clf_cbf.XYDegree(x=3, y=0)],
+        xi_y=clf_cbf.XYDegree(x=2, y=0),
         y=None,
-        rho_minus_V=clf_cbf.CompatibleLagrangianDegrees.Degree(x=2, y=2),
-        h_plus_eps=[clf_cbf.CompatibleLagrangianDegrees.Degree(x=2, y=2)],
+        rho_minus_V=clf_cbf.XYDegree(x=2, y=2),
+        h_plus_eps=[clf_cbf.XYDegree(x=2, y=2)],
         state_eq_constraints=None,
     )
     safety_sets_lagrangian_degrees = clf_cbf.SafetySetLagrangianDegrees(

--- a/examples/power_converter/demo.py
+++ b/examples/power_converter/demo.py
@@ -100,23 +100,15 @@ def search(use_y_squared: bool):
     kappa_h = np.array([kappa_V])
 
     compatible_lagrangian_degrees = clf_cbf.CompatibleLagrangianDegrees(
-        lambda_y=[
-            clf_cbf.CompatibleLagrangianDegrees.Degree(x=2, y=0 if use_y_squared else 1)
-            for _ in range(2)
-        ],
-        xi_y=clf_cbf.CompatibleLagrangianDegrees.Degree(
-            x=2, y=0 if use_y_squared else 1
-        ),
+        lambda_y=[clf_cbf.XYDegree(x=2, y=0 if use_y_squared else 1) for _ in range(2)],
+        xi_y=clf_cbf.XYDegree(x=2, y=0 if use_y_squared else 1),
         y=(
             None
             if use_y_squared
-            else [
-                clf_cbf.CompatibleLagrangianDegrees.Degree(x=4, y=0)
-                for _ in range(compatible.y.size)
-            ]
+            else [clf_cbf.XYDegree(x=4, y=0) for _ in range(compatible.y.size)]
         ),
-        rho_minus_V=clf_cbf.CompatibleLagrangianDegrees.Degree(x=4, y=2),
-        h_plus_eps=[clf_cbf.CompatibleLagrangianDegrees.Degree(x=4, y=2)],
+        rho_minus_V=clf_cbf.XYDegree(x=4, y=2),
+        h_plus_eps=[clf_cbf.XYDegree(x=4, y=2)],
         state_eq_constraints=None,
     )
 

--- a/examples/quadrotor/demo.py
+++ b/examples/quadrotor/demo.py
@@ -100,24 +100,16 @@ def search(use_y_squared: bool, with_u_bound: bool):
     kappa_h_sequences = [np.array([0.2]) for _ in range(len(kappa_V_sequences))]
 
     compatible_lagrangian_degrees = clf_cbf.CompatibleLagrangianDegrees(
-        lambda_y=[
-            clf_cbf.CompatibleLagrangianDegrees.Degree(x=1, y=0 if use_y_squared else 1)
-            for _ in range(4)
-        ],
-        xi_y=clf_cbf.CompatibleLagrangianDegrees.Degree(
-            x=1, y=0 if use_y_squared else 1
-        ),
+        lambda_y=[clf_cbf.XYDegree(x=1, y=0 if use_y_squared else 1) for _ in range(4)],
+        xi_y=clf_cbf.XYDegree(x=1, y=0 if use_y_squared else 1),
         y=(
             None
             if use_y_squared
-            else [
-                clf_cbf.CompatibleLagrangianDegrees.Degree(x=4, y=0)
-                for _ in range(compatible.y.size)
-            ]
+            else [clf_cbf.XYDegree(x=4, y=0) for _ in range(compatible.y.size)]
         ),
-        rho_minus_V=clf_cbf.CompatibleLagrangianDegrees.Degree(x=2, y=2),
-        h_plus_eps=[clf_cbf.CompatibleLagrangianDegrees.Degree(x=2, y=2)],
-        state_eq_constraints=[clf_cbf.CompatibleLagrangianDegrees.Degree(x=2, y=2)],
+        rho_minus_V=clf_cbf.XYDegree(x=2, y=2),
+        h_plus_eps=[clf_cbf.XYDegree(x=2, y=2)],
+        state_eq_constraints=[clf_cbf.XYDegree(x=2, y=2)],
     )
     safety_sets_lagrangian_degrees = [
         clf_cbf.SafetySetLagrangianDegrees(

--- a/examples/quadrotor2d/demo.py
+++ b/examples/quadrotor2d/demo.py
@@ -56,24 +56,16 @@ def main(use_y_squared: bool, with_u_bound: bool):
     solver_options.SetOption(solvers.CommonSolverOption.kPrintToConsole, True)
 
     compatible_lagrangian_degrees = clf_cbf.CompatibleLagrangianDegrees(
-        lambda_y=[
-            clf_cbf.CompatibleLagrangianDegrees.Degree(x=1, y=0 if use_y_squared else 1)
-            for _ in range(2)
-        ],
-        xi_y=clf_cbf.CompatibleLagrangianDegrees.Degree(
-            x=2, y=0 if use_y_squared else 1
-        ),
+        lambda_y=[clf_cbf.XYDegree(x=1, y=0 if use_y_squared else 1) for _ in range(2)],
+        xi_y=clf_cbf.XYDegree(x=2, y=0 if use_y_squared else 1),
         y=(
             None
             if use_y_squared
-            else [
-                clf_cbf.CompatibleLagrangianDegrees.Degree(x=4, y=0)
-                for _ in range(compatible.y.size)
-            ]
+            else [clf_cbf.XYDegree(x=4, y=0) for _ in range(compatible.y.size)]
         ),
-        rho_minus_V=clf_cbf.CompatibleLagrangianDegrees.Degree(x=2, y=2),
-        h_plus_eps=[clf_cbf.CompatibleLagrangianDegrees.Degree(x=2, y=2)],
-        state_eq_constraints=[clf_cbf.CompatibleLagrangianDegrees.Degree(x=2, y=2)],
+        rho_minus_V=clf_cbf.XYDegree(x=2, y=2),
+        h_plus_eps=[clf_cbf.XYDegree(x=2, y=2)],
+        state_eq_constraints=[clf_cbf.XYDegree(x=2, y=2)],
     )
     safety_sets_lagrangian_degrees = clf_cbf.SafetySetLagrangianDegrees(
         exclude=[

--- a/examples/quadrotor2d/demo_taylor.py
+++ b/examples/quadrotor2d/demo_taylor.py
@@ -71,20 +71,15 @@ def search_clf_cbf(
         state_eq_constraints=None,
     )
     lagrangian_degrees = clf_cbf.CompatibleLagrangianDegrees(
-        lambda_y=[
-            clf_cbf.CompatibleLagrangianDegrees.Degree(x=2, y=0) for _ in range(2)
-        ],
-        xi_y=clf_cbf.CompatibleLagrangianDegrees.Degree(x=4, y=0),
+        lambda_y=[clf_cbf.XYDegree(x=2, y=0) for _ in range(2)],
+        xi_y=clf_cbf.XYDegree(x=4, y=0),
         y=(
             None
             if use_y_squared
-            else [
-                clf_cbf.CompatibleLagrangianDegrees.Degree(x=4, y=0)
-                for _ in range(compatible.y.size)
-            ]
+            else [clf_cbf.XYDegree(x=4, y=0) for _ in range(compatible.y.size)]
         ),
-        rho_minus_V=clf_cbf.CompatibleLagrangianDegrees.Degree(x=4, y=2),
-        h_plus_eps=[clf_cbf.CompatibleLagrangianDegrees.Degree(x=4, y=2)],
+        rho_minus_V=clf_cbf.XYDegree(x=4, y=2),
+        h_plus_eps=[clf_cbf.XYDegree(x=4, y=2)],
         state_eq_constraints=None,
     )
     barrier_eps = np.array([0.0])


### PR DESCRIPTION
When the admissible input set is described as a V-rep polyhedron, we can use an alternative formulation to impose the compatibility.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hongkai-dai/compatible_clf_cbf/72)
<!-- Reviewable:end -->
