### PR TITLE
Hocbfs: update functions for adding compatibility SOS contriant

### DIFF
--- a/compatible_clf_cbf/clf_cbf.py
+++ b/compatible_clf_cbf/clf_cbf.py
@@ -320,9 +320,6 @@ class CompatibleLagrangianDegrees:
             degree=self.h_plus_eps,
             lagrangian=h_plus_eps_lagrangian,
         )
-        assert (self.lower_lie_derivative is None) == (
-            lower_lie_derivative_lagrangian is None
-        )
         lower_lie_derivative = (
             None
             if self.lower_lie_derivative is None
@@ -334,7 +331,9 @@ class CompatibleLagrangianDegrees:
                     sos_type,
                     is_sos=True,
                     degree=self.lower_lie_derivative[i],
-                    lagrangian=lower_lie_derivative_lagrangian[i],
+                    lagrangian=(lower_lie_derivative_lagrangian[i]
+                                if lower_lie_derivative_lagrangian is not None
+                                else None),
                 )
                 for i in range(len(self.lower_lie_derivative))
             ]
@@ -547,7 +546,11 @@ class CompatibleWVrepLagrangianDegrees:
                         sos_type,
                         is_sos=True,
                         degree=self.lower_lie_derivative[i],
-                        lagrangian=lower_lie_derivative_lagrangian[i],
+                        lagrangian=(
+                            lower_lie_derivative_lagrangian[i]
+                            if lower_lie_derivative_lagrangian is not None
+                            else None
+                            ),
                     )
                     for i in range(len(self.lower_lie_derivative))
                 ]
@@ -1089,6 +1092,7 @@ class CompatibleClfCbf:
         u_extreme_rays: Optional[np.ndarray] = None,
         num_cbf: int = 1,
         high_order_cbf: bool = False,
+        relative_degrees: Optional[List[int]] = None,
         with_clf: bool = True,
         use_y_squared: bool = True,
         state_eq_constraints: Optional[np.ndarray] = None
@@ -1188,6 +1192,13 @@ class CompatibleClfCbf:
         self.use_y_squared = use_y_squared
         self.num_cbf = num_cbf
         self.high_order_cbf = high_order_cbf
+        if high_order_cbf:
+            assert relative_degrees is not None
+            assert len(relative_degrees) == num_cbf
+            self.relative_degrees = relative_degrees
+        else:
+            assert relative_degrees is None
+            self.relative_degrees = None
         y_size = (
             self.num_cbf
             + (1 if self.with_clf else 0)
@@ -1377,9 +1388,7 @@ class CompatibleClfCbf:
             V=V,
             h=h,
             kappa_V=kappa_V,
-            kappa_h=kappa_h,
-            high_order_kappah=None,
-            relative_degrees=None,
+            kappa_h=kappa_h
         )
         if self.u_vertices is not None or self.u_extreme_rays is not None:
             assert isinstance(lagrangians, CompatibleWVrepLagrangians)
@@ -1390,6 +1399,7 @@ class CompatibleClfCbf:
                 xi=xi,
                 lambda_mat=lambda_mat,
                 lagrangians=lagrangians,
+                kappa_h=kappa_h,
                 barrier_eps=barrier_eps,
                 local_clf=local_clf,
                 sos_type=compatible_sos_type,
@@ -1403,6 +1413,7 @@ class CompatibleClfCbf:
                 xi=xi,
                 lambda_mat=lambda_mat,
                 lagrangians=lagrangians,
+                kappa_h=kappa_h,
                 barrier_eps=barrier_eps,
                 local_clf=local_clf,
                 sos_type=compatible_sos_type,
@@ -1521,7 +1532,8 @@ class CompatibleClfCbf:
             )
         elif compatible_states_options is not None:
             self._add_compatible_states_options(
-                prog, V, h, compatible_states_options, high_order_kappah=None
+                prog, V, h, compatible_states_options, 
+                high_order_kappah=(kappa_h if self.high_order_cbf else None),
             )
 
         result = solve_with_id(
@@ -1925,8 +1937,6 @@ class CompatibleClfCbf:
         h: np.ndarray,
         kappa_V: Optional[float],
         kappa_h: Optional[np.ndarray],
-        high_order_kappah: Optional[np.ndarray],
-        relative_degrees: Optional[List[int]],
     ) -> Tuple[np.ndarray, np.ndarray]:
         """
         Compute
@@ -1962,16 +1972,10 @@ class CompatibleClfCbf:
         """
         # function input check:
         assert h.shape[0] == self.num_cbf
-        if high_order_kappah is not None:
-            assert self.high_order_cbf
-            assert relative_degrees is not None
-            assert len(high_order_kappah) == self.num_cbf
-            assert len(relative_degrees) == self.num_cbf
-        else:
-            assert (
-                kappa_h is not None
-                ), "kappa_h and high_order_kappah should not be both none"
-            assert len(kappa_h) == self.num_cbf
+        if self.high_order_cbf:
+            assert self.relative_degrees is not None
+            assert len(kappa_h.shape) == 2
+            assert kappa_h.shape[0] == self.num_cbf
         if self.with_clf:
             assert V is not None
             assert isinstance(V, sym.Polynomial)
@@ -1988,12 +1992,12 @@ class CompatibleClfCbf:
         xi = np.empty((num_rows,), dtype=object)
 
         # (1) Loading CBFs or HOCBFs constraints:
-        if high_order_kappah is not None:
+        if self.high_order_cbf:
             for i in range(self.num_cbf):
                 current_cbf = h[i]
-                current_r = relative_degrees[i]
+                current_r = self.relative_degrees[i]
                 # xi part
-                beta_vector = elementary_symmetric_polynomials(high_order_kappah[i])
+                beta_vector = elementary_symmetric_polynomials(kappa_h[i])
                 lie_derivative_vector = np.empty(
                     shape=(current_r+1,), dtype=sym.Polynomial
                     )
@@ -2048,6 +2052,7 @@ class CompatibleClfCbf:
         xi: np.ndarray,
         lambda_mat: np.ndarray,
         lagrangians: CompatibleLagrangians,
+        kappa_h: Optional[np.ndarray],
         barrier_eps: Optional[np.ndarray],
         local_clf: bool,
         sos_type=solvers.MathematicalProgram.NonnegativePolynomial.kSos,
@@ -2074,6 +2079,9 @@ class CompatibleClfCbf:
         To certify the emptiness of the set in (2), we can use the sufficient condition
         -1 - s₀(x, y)ᵀ Λ(x)ᵀy² - s₁(x, y)(ξ(x)ᵀy²+1) - s₃(x, y)(1 − V) - s₄(x, y)ᵀ(h(x)+ε) is sos                     (4)
         s₃(x, y), s₄(x, y) are all sos.
+
+        If the CBF is HOCBF, then we also need to extend some terms in the sos polynomial condition (4):
+        -1 - s₀(x, y)ᵀ Λ(x)ᵀy² - s₁(x, y)(ξ(x)ᵀy²+1) - s₃(x, y)(1 − V) - s₄(x, y)ᵀ(h(x)+ε) - s₅(x, y)ᵀPhi[1:r-1]  is sos
 
         Note that we do NOT add the constraint
         s₂(x, y), s₃(x, y), s₄(x, y) are all sos.
@@ -2119,6 +2127,22 @@ class CompatibleClfCbf:
             assert lagrangians.h_plus_eps is not None
             poly -= lagrangians.h_plus_eps.dot(barrier_eps + h)
 
+        # if the CBF is HOCBF, compute s₅(x, y)ᵀPhi[1:r-1]:
+        if lagrangians.lower_lie_derivative is not None:
+            assert len(lagrangians.lower_lie_derivative) == self.num_cbf
+            assert len(kappa_h.shape) == 2
+            assert self.relative_degrees is not None 
+            for i in range(self.num_cbf):
+                lower_lie_derivative_polynomials = lower_lie_derivatives(
+                    poly=h[i], 
+                    vector_field=self.f, 
+                    variables=self.x,
+                    relative_degree=self.relative_degrees[i],
+                    betas=kappa_h[i]
+                )
+                poly -= lagrangians.lower_lie_derivative[i].dot(lower_lie_derivative_polynomials)
+                
+        # if we also have state equation constraints.
         if self.state_eq_constraints is not None:
             assert lagrangians.state_eq_constraints is not None
             poly -= lagrangians.state_eq_constraints.dot(self.state_eq_constraints)
@@ -2135,6 +2159,7 @@ class CompatibleClfCbf:
         xi: np.ndarray,
         lambda_mat: np.ndarray,
         lagrangians: CompatibleWVrepLagrangians,
+        kappa_h: Optional[np.ndarray],
         barrier_eps: Optional[np.ndarray],
         local_clf: bool,
         sos_type=solvers.MathematicalProgram.NonnegativePolynomial.kSos,
@@ -2191,6 +2216,20 @@ class CompatibleClfCbf:
 
         poly -= lagrangians.h_plus_eps.dot(h + barrier_eps)
 
+        # if the CBF is HOCBF, compute s₅(x, y)ᵀPhi[1:r-1]:
+        if lagrangians.lower_lie_derivative is not None:
+            assert len(lagrangians.lower_lie_derivative) == self.num_cbf
+            for i in range(self.num_cbf):
+                lower_lie_derivative_polynomials = lower_lie_derivatives(
+                    poly=h[i], 
+                    vector_field=self.f, 
+                    variables=self.x,
+                    relative_degree=self.relative_degrees[i],
+                    betas=kappa_h[i]
+                )
+                poly -= lagrangians.lower_lie_derivative[i].dot(lower_lie_derivative_polynomials)
+
+        # if we also have state equation constraints:
         if self.state_eq_constraints is not None:
             assert lagrangians.state_eq_constraints is not None
             poly -= lagrangians.state_eq_constraints.dot(self.state_eq_constraints)
@@ -2395,9 +2434,7 @@ class CompatibleClfCbf:
             V=V,
             h=h,
             kappa_V=kappa_V,
-            kappa_h=kappa_h,
-            high_order_kappah=None,
-            relative_degrees=None,
+            kappa_h=kappa_h
         )
 
         if self.u_vertices is not None or self.u_extreme_rays is not None:
@@ -2409,6 +2446,7 @@ class CompatibleClfCbf:
                 xi=xi,
                 lambda_mat=lambda_mat,
                 lagrangians=compatible_lagrangians_new,
+                kappa_h=kappa_h,
                 barrier_eps=barrier_eps,
                 local_clf=local_clf,
                 sos_type=compatible_sos_type,
@@ -2422,6 +2460,7 @@ class CompatibleClfCbf:
                 xi=xi,
                 lambda_mat=lambda_mat,
                 lagrangians=compatible_lagrangians_new,
+                kappa_h=kappa_h,
                 barrier_eps=barrier_eps,
                 local_clf=local_clf,
                 sos_type=compatible_sos_type,
@@ -2595,9 +2634,12 @@ class CompatibleClfCbf:
         compatible_states_options: CompatibleStatesOptions,
         # set the following arguments for HOCBFs:
         high_order_kappah: Optional[List[List[float]]],
-    ):
-        if high_order_kappah is not None:
+    ):  
+        if self.relative_degrees is not None:
+            assert high_order_kappah is not None
             assert len(high_order_kappah) == len(h)
+        else:
+            assert high_order_kappah is None
         compatible_states_options.add_cost(
             prog=prog,
             x=self.x,

--- a/compatible_clf_cbf/clf_cbf.py
+++ b/compatible_clf_cbf/clf_cbf.py
@@ -23,6 +23,8 @@ import pydrake.solvers as solvers
 from compatible_clf_cbf.utils import (
     BinarySearchOptions,
     ContainmentLagrangianDegree,
+    elementary_symmetric_polynomials,
+    lie_derivative,
     lower_lie_derivatives,
     check_array_of_polynomials,
     get_polynomial_result,
@@ -1086,9 +1088,11 @@ class CompatibleClfCbf:
         u_vertices: Optional[np.ndarray] = None,
         u_extreme_rays: Optional[np.ndarray] = None,
         num_cbf: int = 1,
+        high_order_cbf: bool = False,
         with_clf: bool = True,
         use_y_squared: bool = True,
         state_eq_constraints: Optional[np.ndarray] = None,
+        test_mode: bool = False,
     ):
         """
         Args:
@@ -1156,6 +1160,10 @@ class CompatibleClfCbf:
         self.x_set: sym.Variables = sym.Variables(x)
         check_array_of_polynomials(f, self.x_set)
         check_array_of_polynomials(g, self.x_set)
+        if not test_mode:
+            assert (
+                (exclude_sets != []) or (within_set is not None)
+            ), "The exclude_sets and within_set cannot be both None"
         self.exclude_sets = exclude_sets
         self.within_set = within_set
         assert (Au is None) == (bu is None)
@@ -1181,6 +1189,7 @@ class CompatibleClfCbf:
         self.with_clf = with_clf
         self.use_y_squared = use_y_squared
         self.num_cbf = num_cbf
+        self.high_order_cbf = high_order_cbf
         y_size = (
             self.num_cbf
             + (1 if self.with_clf else 0)
@@ -1367,7 +1376,12 @@ class CompatibleClfCbf:
         )
 
         xi, lambda_mat = self._calc_xi_Lambda(
-            V=V, h=h, kappa_V=kappa_V, kappa_h=kappa_h
+            V=V,
+            h=h,
+            kappa_V=kappa_V,
+            kappa_h=kappa_h,
+            high_order_kappah=None,
+            relative_degrees=None,
         )
         if self.u_vertices is not None or self.u_extreme_rays is not None:
             assert isinstance(lagrangians, CompatibleWVrepLagrangians)
@@ -1912,7 +1926,9 @@ class CompatibleClfCbf:
         V: Optional[sym.Polynomial],
         h: np.ndarray,
         kappa_V: Optional[float],
-        kappa_h: np.ndarray,
+        kappa_h: Optional[np.ndarray],
+        high_order_kappah: Optional[np.ndarray],
+        relative_degrees: Optional[List[int]],
     ) -> Tuple[np.ndarray, np.ndarray]:
         """
         Compute
@@ -1923,6 +1939,21 @@ class CompatibleClfCbf:
                [-∂V/∂x*f(x)-κ_V*V(x)]
                [                 bu ]
 
+        In the jornal paper, the HOCBF formula is given by a vecotr Phi(x)≥ 0
+        If the HOCBF has relative degree r, then the Phi(x) vector would be:
+        Phi(x) = [Phi_0(x), Phi_1(x), ..., Phi_(r-1)(x), Phi_r(x)],
+        where Phi_0(x) = h(x), Phi_1(x)...Phi_(r-1)(x) are computed by
+        "Lower_lie_derivative" function in utils.py.
+
+        Here, in the ξ(x) and Λ(x), we incorperate the Phi_r(x).
+        For example, if the HOCBF has relative degree r=3, then Λ(x) and ξ(x) are:
+        Λ(x) =  [-Lf³Lgh(x),]
+                [ LgV(x),   ]
+                [ Au        ]
+        ξ(x) =  [(β1 + β2 + β3)Lf²h(x) + (β1β2 + β2β3 + β1β3)Lfh(x) + (β1β2β3)h(x),]
+                [ LfV(x) + κ_VV(x),]
+                [ bu               ]
+
         Args:
           V: The CLF function. If with_clf is False, then V is None.
           h: An array of CBFs. h[i] is the CBF for the i'th unsafe region.
@@ -1931,33 +1962,81 @@ class CompatibleClfCbf:
         Returns:
           (xi, lambda_mat) ξ(x) and Λ(x) in the documentation above.
         """
+        # function input check:
+        assert h.shape[0] == self.num_cbf
+        if high_order_kappah is not None:
+            assert self.high_order_cbf
+            assert relative_degrees is not None
+            assert len(high_order_kappah) == self.num_cbf
+            assert len(relative_degrees) == self.num_cbf
+        else:
+            assert (
+                kappa_h is not None
+                ), "kappa_h and high_order_kappah should not be both none"
+            assert len(kappa_h) == self.num_cbf
         if self.with_clf:
             assert V is not None
             assert isinstance(V, sym.Polynomial)
-            dVdx = V.Jacobian(self.x)
-            xi_rows = self.num_cbf + 1
+            num_rows = self.num_cbf + 1
         else:
             assert V is None
-            dVdx = None
-            xi_rows = self.num_cbf
+            num_rows = self.num_cbf
             assert h.size > 1, "You should use multiple CBF when with_clf is False."
         if self.Au is not None:
-            xi_rows += self.Au.shape[0]
-        assert h.shape == (self.num_cbf,)
-        assert kappa_h.shape == h.shape
-        dhdx = np.concatenate(
-            [h[i].Jacobian(self.x).reshape((1, -1)) for i in range(h.size)], axis=0
-        )
-        lambda_mat = np.empty((xi_rows, self.nu), dtype=object)
-        lambda_mat[: self.num_cbf] = -dhdx @ self.g
-        xi = np.empty((xi_rows,), dtype=object)
-        xi[: self.num_cbf] = dhdx @ self.f + kappa_h * h
+            num_rows += self.Au.shape[0]
 
+        # create empty Λ(x) and ξ(x)
+        lambda_mat = np.empty((num_rows, self.nu), dtype=object)
+        xi = np.empty((num_rows,), dtype=object)
+
+        # (1) Loading CBFs or HOCBFs constraints:
+        if high_order_kappah is not None:
+            for i in range(self.num_cbf):
+                current_cbf = h[i]
+                current_r = relative_degrees[i]
+                beta_vector = elementary_symmetric_polynomials(high_order_kappah[i])
+                lie_derivative_vector = np.array([
+                    lie_derivative(
+                        poly=current_cbf,
+                        vector_feild=self.f,
+                        variables=self.x,
+                        pow=j
+                        )
+                    for j in range(current_r, -1, -1)
+                ])
+                xi_element = np.dot(lie_derivative_vector, beta_vector)
+                xi[i] = xi_element
+
+                Lfb_r_1 = lie_derivative(
+                    poly=current_cbf,
+                    vector_feild=self.f,
+                    variables=self.x,
+                    pow=current_r-1
+                    )
+                LfLgb = lie_derivative(
+                    poly=Lfb_r_1,
+                    vector_feild=self.g,
+                    variables=self.x,
+                    pow=1
+                    )
+                lambda_element = -LfLgb
+                lambda_mat[i] = lambda_element
+        else:
+            dhdx = np.concatenate(
+                [h[i].Jacobian(self.x).reshape((1, -1)) for i in range(h.size)],
+                axis=0
+            )
+            lambda_mat[: self.num_cbf] = -dhdx @ self.g
+            xi[: self.num_cbf] = dhdx @ self.f + kappa_h * h
+
+        # (2) Loading CLF constraints:
         if self.with_clf:
             assert V is not None
-            assert dVdx is not None
+            dVdx = V.Jacobian(self.x)
             lambda_mat[self.num_cbf] = dVdx @ self.g
             xi[self.num_cbf] = -dVdx.dot(self.f) - kappa_V * V
+
+        # (3) Loading input constraints:
         if self.Au is not None:
             lambda_mat[-self.Au.shape[0] :] = self.Au
             xi[-self.Au.shape[0] :] = self.bu
@@ -2317,7 +2396,12 @@ class CompatibleClfCbf:
             )
 
         xi, lambda_mat = self._calc_xi_Lambda(
-            V=V, h=h, kappa_V=kappa_V, kappa_h=kappa_h
+            V=V,
+            h=h,
+            kappa_V=kappa_V,
+            kappa_h=kappa_h,
+            high_order_kappah=None,
+            relative_degrees=None,
         )
 
         if self.u_vertices is not None or self.u_extreme_rays is not None:

--- a/compatible_clf_cbf/clf_cbf.py
+++ b/compatible_clf_cbf/clf_cbf.py
@@ -1939,7 +1939,7 @@ class CompatibleClfCbf:
                [-∂V/∂x*f(x)-κ_V*V(x)]
                [                 bu ]
 
-        In the jornal paper, the HOCBF formula is given by a vecotr Phi(x)≥ 0
+        In the journal paper, the HOCBF formula is given by a vector Phi(x)≥ 0
         If the HOCBF has relative degree r, then the Phi(x) vector would be:
         Phi(x) = [Phi_0(x), Phi_1(x), ..., Phi_(r-1)(x), Phi_r(x)],
         where Phi_0(x) = h(x), Phi_1(x)...Phi_(r-1)(x) are computed by
@@ -1994,19 +1994,22 @@ class CompatibleClfCbf:
             for i in range(self.num_cbf):
                 current_cbf = h[i]
                 current_r = relative_degrees[i]
+                # xi part
                 beta_vector = elementary_symmetric_polynomials(high_order_kappah[i])
-                lie_derivative_vector = np.array([
-                    lie_derivative(
-                        poly=current_cbf,
+                lie_derivative_vector = np.empty(
+                    shape=(current_r+1,), dtype=sym.Polynomial
+                    )
+                lie_derivative_vector[-1] = current_cbf
+                for j in range(current_r, 0, -1):
+                    lie_derivative_vector[j-1] = lie_derivative(
+                        poly=lie_derivative_vector[j],
                         vector_feild=self.f,
                         variables=self.x,
-                        pow=j
-                        )
-                    for j in range(current_r, -1, -1)
-                ])
+                        pow=1
+                    )
                 xi_element = np.dot(lie_derivative_vector, beta_vector)
                 xi[i] = xi_element
-
+                # lambda part
                 Lfb_r_1 = lie_derivative(
                     poly=current_cbf,
                     vector_feild=self.f,

--- a/compatible_clf_cbf/clf_cbf.py
+++ b/compatible_clf_cbf/clf_cbf.py
@@ -1091,8 +1091,7 @@ class CompatibleClfCbf:
         high_order_cbf: bool = False,
         with_clf: bool = True,
         use_y_squared: bool = True,
-        state_eq_constraints: Optional[np.ndarray] = None,
-        test_mode: bool = False,
+        state_eq_constraints: Optional[np.ndarray] = None
     ):
         """
         Args:
@@ -1160,10 +1159,9 @@ class CompatibleClfCbf:
         self.x_set: sym.Variables = sym.Variables(x)
         check_array_of_polynomials(f, self.x_set)
         check_array_of_polynomials(g, self.x_set)
-        if not test_mode:
-            assert (
-                (exclude_sets != []) or (within_set is not None)
-            ), "The exclude_sets and within_set cannot be both None"
+        assert (
+            (exclude_sets != []) or (within_set is not None)
+        ), "The exclude_sets and within_set cannot be both None"
         self.exclude_sets = exclude_sets
         self.within_set = within_set
         assert (Au is None) == (bu is None)
@@ -1947,7 +1945,7 @@ class CompatibleClfCbf:
 
         Here, in the ξ(x) and Λ(x), we incorperate the Phi_r(x).
         For example, if the HOCBF has relative degree r=3, then Λ(x) and ξ(x) are:
-        Λ(x) =  [-Lf³Lgh(x),]
+        Λ(x) =  [-Lf²Lgh(x),]
                 [ LgV(x),   ]
                 [ Au        ]
         ξ(x) =  [(β1 + β2 + β3)Lf²h(x) + (β1β2 + β2β3 + β1β3)Lfh(x) + (β1β2β3)h(x),]
@@ -2010,14 +2008,9 @@ class CompatibleClfCbf:
                 xi_element = np.dot(lie_derivative_vector, beta_vector)
                 xi[i] = xi_element
                 # lambda part
-                Lfb_r_1 = lie_derivative(
-                    poly=current_cbf,
-                    vector_feild=self.f,
-                    variables=self.x,
-                    pow=current_r-1
-                    )
+                # compute Lf⁽ʳ⁻¹⁾Lgh(x) = ∂Lf⁽ʳ⁻¹⁾h(x)/∂x * g(x):
                 LfLgb = lie_derivative(
-                    poly=Lfb_r_1,
+                    poly=lie_derivative_vector[1],
                     vector_feild=self.g,
                     variables=self.x,
                     pow=1

--- a/compatible_clf_cbf/utils.py
+++ b/compatible_clf_cbf/utils.py
@@ -70,7 +70,7 @@ def lower_lie_derivatives(
         Lf^nb(x)+(βn+βn-1+...+β2+β1)Lf^(n-1)b(x)+
         ...
         +β1β2b(x)≥0,
-    this function computes an array of polynomials:
+    this function computes the following array of polynomials:
         Lfb(x)+β1b(x)
         Lf^2b(x)+(β2+β1)Lfb(x)+β1β2b(x)
         ...
@@ -78,6 +78,9 @@ def lower_lie_derivatives(
     this function computes the elements:
       Phi_1(x), Phi_2(x), ..., Phi_(n-1)(x) (without Phi_0(x))
     in that vector, where n is the relative degree.
+
+    Noted that Phi_0(x) is the CBF itself, and Phi_n(x) will be computed in the
+    Λ(x) matrix and ξ(x) vector.
     """
 
     output = np.empty(relative_degree - 1, dtype=object)

--- a/examples/nonlinear_toy/demo_trigpoly.py
+++ b/examples/nonlinear_toy/demo_trigpoly.py
@@ -373,7 +373,7 @@ def main():
 
     V, h = search(use_v_rep=False, unit_test_flag=args.unit_test)
     if not args.unit_test:
-        # visualize()
+        visualize()
         pass
 
 

--- a/examples/nonlinear_toy/synthesize_demo.py
+++ b/examples/nonlinear_toy/synthesize_demo.py
@@ -72,6 +72,10 @@ def main(with_u_bound: bool):
         h_anchor_bounds=[(np.array([0]), np.array([0.1]))],
         weight_V=1.0,
         weight_h=np.array([1.0]),
+        relative_degrees=None,
+        weight_lower_lie_derivatives=None,
+        V_margin=None,
+        h_margins=None,
     )
 
     solver_options = solvers.SolverOptions()

--- a/tests/test_clf_cbf.py
+++ b/tests/test_clf_cbf.py
@@ -7,6 +7,7 @@ import pytest  # noqa
 
 import pydrake.solvers as solvers
 import pydrake.symbolic as sym
+import pydrake.systems.controllers as controller
 
 import compatible_clf_cbf.ellipsoid_utils as ellipsoid_utils
 import compatible_clf_cbf.utils as utils
@@ -442,9 +443,7 @@ class TestClfCbf(object):
             V=V,
             h=h,
             kappa_V=kappa_V,
-            kappa_h=kappa_h,
-            high_order_kappah=None,
-            relative_degrees=None,
+            kappa_h=kappa_h
             )
         assert xi.shape == (1 + dut.num_cbf,)
         assert lambda_mat.shape == (1 + dut.num_cbf, dut.nu)
@@ -492,9 +491,7 @@ class TestClfCbf(object):
             V=V,
             h=h,
             kappa_V=kappa_V,
-            kappa_h=kappa_h,
-            high_order_kappah=None,
-            relative_degrees=None,
+            kappa_h=kappa_h
             )
         assert xi.shape == (dut.num_cbf,)
         assert lambda_mat.shape == (dut.num_cbf, dut.nu)
@@ -541,9 +538,7 @@ class TestClfCbf(object):
             V=V,
             h=h,
             kappa_V=kappa_V,
-            kappa_h=kappa_h,
-            high_order_kappah=None,
-            relative_degrees=None,
+            kappa_h=kappa_h
             )
 
         dVdx = V.Jacobian(self.x)
@@ -601,13 +596,13 @@ class TestClfCbf(object):
             bu=np.array([1, 1]),
             num_cbf=2,
             high_order_cbf=True,
-            with_clf=True
+            relative_degrees=[2, 2],
+            with_clf=True,
         )
         V = sym.Polynomial(x[0] ** 2 + x[1] ** 2)
         h = np.array([sym.Polynomial(1 - x[0]), sym.Polynomial(1 + x[0])])
         kappa_V = 0.01
-        high_order_kappah = [[0.1, 0.1], [0.1, 0.1]]
-        relative_degrees = [2, 2]
+        kappah = np.array([[0.1, 0.1], [0.1, 0.1]])
         # compute the expected Lambda and xi by hand:
         LfV = 2*x[0]*x[1]
         LgV = 2*x[1]
@@ -617,10 +612,10 @@ class TestClfCbf(object):
         Lf2h2 = 0
         LgLfh1 = -1
         LgLfh2 = 1
-        beta_11 = high_order_kappah[0][0]
-        beta_12 = high_order_kappah[0][1]
-        beta_21 = high_order_kappah[1][0]
-        beta_22 = high_order_kappah[1][1]
+        beta_11 = kappah[0][0]
+        beta_12 = kappah[0][1]
+        beta_21 = kappah[1][0]
+        beta_22 = kappah[1][1]
         lambda_mat_expected = np.array([
             [sym.Polynomial(-LgLfh1)],
             [sym.Polynomial(-LgLfh2)],
@@ -642,9 +637,7 @@ class TestClfCbf(object):
             V=V,
             h=h,
             kappa_V=kappa_V,
-            kappa_h=None,
-            high_order_kappah=high_order_kappah,
-            relative_degrees=relative_degrees,
+            kappa_h=kappah
         )
 
         assert xi.shape == xi_expected.shape
@@ -703,7 +696,7 @@ class TestClfCbf(object):
         prog, lagrangians = dut.construct_search_compatible_lagrangians(
             V, h, kappa_V, kappa_h, lagrangian_degrees, barrier_eps
         )
-
+    
     def test_add_compatibility_w_clf_y_squared(self):
         """
         Test _add_compatibility with CLF and use_y_squared=True
@@ -759,9 +752,7 @@ class TestClfCbf(object):
             V=V,
             h=h,
             kappa_V=kappa_V,
-            kappa_h=kappa_h,
-            high_order_kappah=None,
-            relative_degrees=None,
+            kappa_h=kappa_h
             )
 
         barrier_eps = np.array([0.01, 0.02])
@@ -772,6 +763,7 @@ class TestClfCbf(object):
             xi=xi,
             lambda_mat=lambda_mat,
             lagrangians=lagrangians,
+            kappa_h=None,
             barrier_eps=barrier_eps,
             local_clf=True,
         )
@@ -834,9 +826,7 @@ class TestClfCbf(object):
             V=V,
             h=h,
             kappa_V=kappa_V,
-            kappa_h=kappa_h,
-            high_order_kappah=None,
-            relative_degrees=None,
+            kappa_h=kappa_h
             )
         barrier_eps = np.array([0.01, 0.02])
         poly = dut._add_compatibility_w_vrep(
@@ -846,6 +836,7 @@ class TestClfCbf(object):
             xi=xi,
             lambda_mat=lambda_mat,
             lagrangians=lagrangians,
+            kappa_h=None,
             barrier_eps=barrier_eps,
             local_clf=True,
         )
@@ -916,9 +907,7 @@ class TestClfCbf(object):
             V=V,
             h=h,
             kappa_V=kappa_V,
-            kappa_h=kappa_h,
-            high_order_kappah=None,
-            relative_degrees=None,
+            kappa_h=kappa_h
             )
         barrier_eps = np.array([0.01, 0.02])
         poly = dut._add_compatibility_w_vrep(
@@ -928,6 +917,7 @@ class TestClfCbf(object):
             xi=xi,
             lambda_mat=lambda_mat,
             lagrangians=lagrangians,
+            kappa_h=None,
             barrier_eps=barrier_eps,
             local_clf=True,
         )
@@ -1883,3 +1873,218 @@ class TestCompatibleWithU:
         self.intersect_tester(
             lambda_mat, xi, u_vertices, u_extreme_rays, intersect_expected=False
         )
+
+
+class TestCLfCbfWHocbfs:
+    
+    @classmethod
+    def setup_class(cls):
+        # we use a 1D double intergrator for testing
+        cls.nx = 2
+        cls.nu = 1
+        cls.x = sym.MakeVectorContinuousVariable(cls.nx, "x")
+        cls.f = np.array([
+            sym.Polynomial(cls.x[1]),
+            sym.Polynomial(0)
+        ])
+        cls.g = np.array([
+            [sym.Polynomial(0)], 
+            [sym.Polynomial(1)]
+            ])
+        cls.exclude_sets = [
+            mut.ExcludeSet(np.array([
+                sym.Polynomial(cls.x[0] + 10),
+                sym.Polynomial(-cls.x[0] + 10)
+            ]))
+        ]
+        cls.within_set = None
+        
+        _, S = controller.LinearQuadraticRegulator(
+            A = np.array([
+                [0, 1],
+                [0, 0]
+                ]),
+            B = np.array([[0], [1]]),
+            Q = np.eye(2),
+            R = np.eye(1),
+        )
+        cls.V = sym.Polynomial(np.dot(cls.x, np.dot(S, cls.x)))
+        cls.h = np.array([
+            sym.Polynomial(cls.x[0] + 5),
+            sym.Polynomial(-cls.x[0] + 5)
+        ])
+
+        cls.kappa_V = 0.1
+        cls.kappa_h = np.array([
+            [1, 1], [1, 1]
+        ])
+        cls.relative_degrees = [2, 2]
+        cls.barrier_eps = np.array([0.01, 0.01])
+    
+    def test_add_compatibility_w_hocbf(self):
+        dut = mut.CompatibleClfCbf(
+            f=self.f,
+            g=self.g,
+            x=self.x,
+            exclude_sets=self.exclude_sets,
+            within_set=self.within_set,
+            Au=None,
+            bu=None,
+            num_cbf=2,
+            high_order_cbf=True,
+            relative_degrees=self.relative_degrees,
+            with_clf=True,
+            use_y_squared=True,
+        )
+        prog = solvers.MathematicalProgram()
+        prog.AddIndeterminates(dut.xy_set)
+
+        lagrangian_degrees = mut.CompatibleLagrangianDegrees(
+            lambda_y=[mut.XYDegree(x=2, y=0)],
+            xi_y=mut.XYDegree(x=2, y=0),
+            y=None,
+            y_cross=None,
+            rho_minus_V=mut.XYDegree(x=2, y=2),
+            h_plus_eps=[mut.XYDegree(x=2, y=2), mut.XYDegree(x=2, y=2)],
+            lower_lie_derivative=[
+                [mut.XYDegree(x=2, y=2)],
+                [mut.XYDegree(x=2, y=2)],
+                ],
+            state_eq_constraints=None,
+        )
+
+        lagrangians =lagrangian_degrees.to_lagrangians(
+            prog=prog,
+            x=dut.x_set,
+            y=dut.y_set
+        )
+
+        xi_vec, lambda_mat = dut._calc_xi_Lambda(
+            V=self.V,
+            h=self.h,
+            kappa_V=self.kappa_V,
+            kappa_h=self.kappa_h,
+        )
+
+        poly = dut._add_compatibility(
+            prog=prog,
+            V=self.V,
+            h=self.h,
+            xi=xi_vec,
+            lambda_mat=lambda_mat,
+            lagrangians=lagrangians,
+            kappa_h=self.kappa_h,
+            barrier_eps=self.barrier_eps,
+            local_clf=True,
+        )
+
+        lower_lie_derivative_polys_h0 = utils.lower_lie_derivatives(
+            poly=self.h[0],
+            vector_field=self.f,
+            variables=self.x,
+            relative_degree=self.relative_degrees[0],
+            betas=self.kappa_h[0]
+        )
+        lower_lie_derivative_polys_h1 = utils.lower_lie_derivatives(
+            poly=self.h[1],
+            vector_field=self.f,
+            variables=self.x,
+            relative_degree=self.relative_degrees[1],
+            betas=self.kappa_h[1]
+        )
+        expected_poly = (
+            -1 
+            -np.dot(lagrangians.lambda_y, np.dot(lambda_mat.T, dut.y_squared_poly))
+            -lagrangians.xi_y * (xi_vec.dot(dut.y_squared_poly) + 1)
+            -lagrangians.rho_minus_V * (1 - self.V)
+            -lagrangians.h_plus_eps.dot(self.h + self.barrier_eps)
+            -lagrangians.lower_lie_derivative[0].dot(lower_lie_derivative_polys_h0)
+            -lagrangians.lower_lie_derivative[1].dot(lower_lie_derivative_polys_h1)
+        )
+
+        assert poly.CoefficientsAlmostEqual(expected_poly, tolerance=1e-5)
+
+    def test_add_compatibility_v_rep_w_hocbf(self):
+        dut = mut.CompatibleClfCbf(
+            f=self.f,
+            g=self.g,
+            x=self.x,
+            exclude_sets=self.exclude_sets,
+            within_set=self.within_set,
+            Au=None,
+            bu=None,
+            u_vertices=np.array([[-1], [1]]),
+            u_extreme_rays=None,
+            num_cbf=2,
+            high_order_cbf=True,
+            relative_degrees=self.relative_degrees,
+            with_clf=True,
+            use_y_squared=True,
+        )
+        prog = solvers.MathematicalProgram()
+        prog.AddIndeterminates(dut.xy_set)
+
+        lagrangian_degrees = mut.CompatibleWVrepLagrangianDegrees(
+            u_vertices=[
+                mut.XYDegree(x=2, y=2) 
+                for _ in range(dut.u_vertices.shape[0])
+                ],
+            u_extreme_rays=None,
+            y=None,
+            y_cross=None,
+            rho_minus_V=mut.XYDegree(x=2, y=2),
+            h_plus_eps=[mut.XYDegree(x=2, y=4) for _ in range(self.h.size)],
+            lower_lie_derivative=[
+                [mut.XYDegree(x=2, y=2)],
+                [mut.XYDegree(x=2, y=2)],
+                ],
+            state_eq_constraints=None,
+        )
+        lagrangians = lagrangian_degrees.to_lagrangians(prog, dut.x_set, dut.y_set)
+
+        xi, lambda_mat = dut._calc_xi_Lambda(
+            V=self.V,
+            h=self.h,
+            kappa_V=self.kappa_V,
+            kappa_h=self.kappa_h
+            )
+        barrier_eps = np.array([0.01, 0.02])
+        poly = dut._add_compatibility_w_vrep(
+            prog=prog,
+            V=self.V,
+            h=self.h,
+            xi=xi,
+            lambda_mat=lambda_mat,
+            lagrangians=lagrangians,
+            kappa_h=self.kappa_h,
+            barrier_eps=barrier_eps,
+            local_clf=True,
+        )
+
+        lower_lie_derivative_polys_h0 = utils.lower_lie_derivatives(
+            poly=self.h[0],
+            vector_field=self.f,
+            variables=self.x,
+            relative_degree=self.relative_degrees[0],
+            betas=self.kappa_h[0]
+        )
+        lower_lie_derivative_polys_h1 = utils.lower_lie_derivatives(
+            poly=self.h[1],
+            vector_field=self.f,
+            variables=self.x,
+            relative_degree=self.relative_degrees[1],
+            betas=self.kappa_h[1]
+        )
+
+        expected_poly = (
+            -1
+            - lagrangians.u_vertices.dot(
+                -xi.dot(dut.y_squared_poly) + dut.y_squared_poly @ (lambda_mat @ dut.u_vertices.T) - 1
+            )
+            - lagrangians.rho_minus_V * (1 - self.V)
+            - lagrangians.h_plus_eps.dot(self.h + barrier_eps)
+            - lagrangians.lower_lie_derivative[0].dot(lower_lie_derivative_polys_h0)
+            - lagrangians.lower_lie_derivative[1].dot(lower_lie_derivative_polys_h1)
+        )
+
+        assert poly.CoefficientsAlmostEqual(expected_poly, tolerance=1e-5)

--- a/tests/test_clf_cbf.py
+++ b/tests/test_clf_cbf.py
@@ -595,14 +595,13 @@ class TestClfCbf(object):
             f=f,
             g=g,
             x=x,
-            exclude_sets=[],
+            exclude_sets=[mut.ExcludeSet(np.array([sym.Polynomial(x[0] + 1)]))],
             within_set=None,
             Au=np.array([[1], [-1]]),
             bu=np.array([1, 1]),
             num_cbf=2,
             high_order_cbf=True,
-            with_clf=True,
-            test_mode=True
+            with_clf=True
         )
         V = sym.Polynomial(x[0] ** 2 + x[1] ** 2)
         h = np.array([sym.Polynomial(1 - x[0]), sym.Polynomial(1 + x[0])])

--- a/tests/test_clf_cbf.py
+++ b/tests/test_clf_cbf.py
@@ -438,7 +438,14 @@ class TestClfCbf(object):
         )
         kappa_V = 0.01
         kappa_h = np.array([0.02, 0.03])
-        xi, lambda_mat = dut._calc_xi_Lambda(V=V, h=h, kappa_V=kappa_V, kappa_h=kappa_h)
+        xi, lambda_mat = dut._calc_xi_Lambda(
+            V=V,
+            h=h,
+            kappa_V=kappa_V,
+            kappa_h=kappa_h,
+            high_order_kappah=None,
+            relative_degrees=None,
+            )
         assert xi.shape == (1 + dut.num_cbf,)
         assert lambda_mat.shape == (1 + dut.num_cbf, dut.nu)
         dhdx = np.empty((2, 3), dtype=object)
@@ -481,7 +488,14 @@ class TestClfCbf(object):
         )
         kappa_V = None
         kappa_h = np.array([0.02, 0.03])
-        xi, lambda_mat = dut._calc_xi_Lambda(V=V, h=h, kappa_V=kappa_V, kappa_h=kappa_h)
+        xi, lambda_mat = dut._calc_xi_Lambda(
+            V=V,
+            h=h,
+            kappa_V=kappa_V,
+            kappa_h=kappa_h,
+            high_order_kappah=None,
+            relative_degrees=None,
+            )
         assert xi.shape == (dut.num_cbf,)
         assert lambda_mat.shape == (dut.num_cbf, dut.nu)
         dhdx = np.empty((2, 3), dtype=object)
@@ -523,7 +537,14 @@ class TestClfCbf(object):
         )
         kappa_V = 0.01
         kappa_h = np.array([0.02, 0.03])
-        xi, lambda_mat = dut._calc_xi_Lambda(V=V, h=h, kappa_V=kappa_V, kappa_h=kappa_h)
+        xi, lambda_mat = dut._calc_xi_Lambda(
+            V=V,
+            h=h,
+            kappa_V=kappa_V,
+            kappa_h=kappa_h,
+            high_order_kappah=None,
+            relative_degrees=None,
+            )
 
         dVdx = V.Jacobian(self.x)
         dhdx = np.empty((2, self.nx), dtype=object)
@@ -561,6 +582,87 @@ class TestClfCbf(object):
                     assert lambda_mat[i, j].CoefficientsAlmostEqual(
                         lambda_mat_expected[i, j], 1e-8
                     )
+
+    def test_calc_xi_Lambda_w_hocbf(self):
+        """
+        Test _calc_xi_Lambda with HOCBFs, clf and Au bu
+        """
+        # In this test, we try a new set-up:
+        x = sym.MakeVectorContinuousVariable(2, "x")
+        f = np.array([sym.Polynomial(x[1]), sym.Polynomial()])
+        g = np.array([[sym.Polynomial()], [sym.Polynomial(1)]])
+        dut = mut.CompatibleClfCbf(
+            f=f,
+            g=g,
+            x=x,
+            exclude_sets=[],
+            within_set=None,
+            Au=np.array([[1], [-1]]),
+            bu=np.array([1, 1]),
+            num_cbf=2,
+            high_order_cbf=True,
+            with_clf=True,
+            test_mode=True
+        )
+        V = sym.Polynomial(x[0] ** 2 + x[1] ** 2)
+        h = np.array([sym.Polynomial(1 - x[0]), sym.Polynomial(1 + x[0])])
+        kappa_V = 0.01
+        high_order_kappah = [[0.1, 0.1], [0.1, 0.1]]
+        relative_degrees = [2, 2]
+        # compute the expected Lambda and xi by hand:
+        LfV = 2*x[0]*x[1]
+        LgV = 2*x[1]
+        Lfh1 = -x[1]
+        Lfh2 = x[1]
+        Lf2h1 = 0
+        Lf2h2 = 0
+        LgLfh1 = -1
+        LgLfh2 = 1
+        beta_11 = high_order_kappah[0][0]
+        beta_12 = high_order_kappah[0][1]
+        beta_21 = high_order_kappah[1][0]
+        beta_22 = high_order_kappah[1][1]
+        lambda_mat_expected = np.array([
+            [sym.Polynomial(-LgLfh1)],
+            [sym.Polynomial(-LgLfh2)],
+            [sym.Polynomial(LgV)]
+        ])
+        lambda_mat_expected = np.concatenate((lambda_mat_expected, dut.Au), axis=0)
+        xi_expected = np.array([
+            sym.Polynomial(
+                Lf2h1 + (beta_11 + beta_12) * Lfh1 + (beta_11*beta_12) * h[0]
+                ),
+            sym.Polynomial(
+                Lf2h2 + (beta_21 + beta_22) * Lfh2 + (beta_21*beta_22) * h[1]
+                ),
+            sym.Polynomial(-LfV - kappa_V * V),
+        ])
+        xi_expected = np.concatenate((xi_expected, dut.bu), axis=0)
+
+        xi, lambda_mat = dut._calc_xi_Lambda(
+            V=V,
+            h=h,
+            kappa_V=kappa_V,
+            kappa_h=None,
+            high_order_kappah=high_order_kappah,
+            relative_degrees=relative_degrees,
+        )
+
+        assert xi.shape == xi_expected.shape
+        assert lambda_mat.shape == lambda_mat_expected.shape
+        assert lambda_mat.shape[0] == xi.shape[0]
+        assert lambda_mat.shape[1] == dut.nu
+        for i in range(0, xi.shape[0]):
+            if isinstance(xi[i], float):
+                assert xi[i] == xi_expected[i]
+            if isinstance(xi[i], sym.Polynomial):
+                assert xi[i].EqualTo(xi_expected[i])
+        for i in range(0, lambda_mat.shape[0]):
+            for j in range(0, lambda_mat.shape[1]):
+                if isinstance(lambda_mat[i, j], float):
+                    assert lambda_mat[i, j] == lambda_mat_expected[i, j]
+                if isinstance(lambda_mat[i, j], sym.Polynomial):
+                    assert lambda_mat[i, j].EqualTo(lambda_mat_expected[i, j])
 
     def test_search_compatible_lagrangians_w_clf_y_squared(self):
         """
@@ -654,7 +756,14 @@ class TestClfCbf(object):
             state_eq_constraints=None,
         )
 
-        xi, lambda_mat = dut._calc_xi_Lambda(V=V, h=h, kappa_V=kappa_V, kappa_h=kappa_h)
+        xi, lambda_mat = dut._calc_xi_Lambda(
+            V=V,
+            h=h,
+            kappa_V=kappa_V,
+            kappa_h=kappa_h,
+            high_order_kappah=None,
+            relative_degrees=None,
+            )
 
         barrier_eps = np.array([0.01, 0.02])
         poly = dut._add_compatibility(
@@ -722,7 +831,14 @@ class TestClfCbf(object):
         )
         lagrangians = lagrangian_degrees.to_lagrangians(prog, dut.x_set, dut.y_set)
 
-        xi, lambda_mat = dut._calc_xi_Lambda(V=V, h=h, kappa_V=kappa_V, kappa_h=kappa_h)
+        xi, lambda_mat = dut._calc_xi_Lambda(
+            V=V,
+            h=h,
+            kappa_V=kappa_V,
+            kappa_h=kappa_h,
+            high_order_kappah=None,
+            relative_degrees=None,
+            )
         barrier_eps = np.array([0.01, 0.02])
         poly = dut._add_compatibility_w_vrep(
             prog=prog,
@@ -797,7 +913,14 @@ class TestClfCbf(object):
         )
         lagrangians = lagrangian_degrees.to_lagrangians(prog, dut.x_set, dut.y_set)
 
-        xi, lambda_mat = dut._calc_xi_Lambda(V=V, h=h, kappa_V=kappa_V, kappa_h=kappa_h)
+        xi, lambda_mat = dut._calc_xi_Lambda(
+            V=V,
+            h=h,
+            kappa_V=kappa_V,
+            kappa_h=kappa_h,
+            high_order_kappah=None,
+            relative_degrees=None,
+            )
         barrier_eps = np.array([0.01, 0.02])
         poly = dut._add_compatibility_w_vrep(
             prog=prog,


### PR DESCRIPTION
Included langragian multiply lower_lie_derivative_polys into the following functions:
1. _add_compatibility()
2. _add_comaptibility_w_vrep

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hongkai-dai/compatible_clf_cbf/87)
<!-- Reviewable:end -->
