### PR TITLE
Included HOCBFs into compatibility SOS constraints

### DIFF
--- a/compatible_clf_cbf/clf_cbf.py
+++ b/compatible_clf_cbf/clf_cbf.py
@@ -320,9 +320,6 @@ class CompatibleLagrangianDegrees:
             degree=self.h_plus_eps,
             lagrangian=h_plus_eps_lagrangian,
         )
-        assert (self.lower_lie_derivative is None) == (
-            lower_lie_derivative_lagrangian is None
-        )
         lower_lie_derivative = (
             None
             if self.lower_lie_derivative is None
@@ -334,7 +331,9 @@ class CompatibleLagrangianDegrees:
                     sos_type,
                     is_sos=True,
                     degree=self.lower_lie_derivative[i],
-                    lagrangian=lower_lie_derivative_lagrangian[i],
+                    lagrangian=(lower_lie_derivative_lagrangian[i]
+                                if lower_lie_derivative_lagrangian is not None
+                                else None),
                 )
                 for i in range(len(self.lower_lie_derivative))
             ]
@@ -547,7 +546,11 @@ class CompatibleWVrepLagrangianDegrees:
                         sos_type,
                         is_sos=True,
                         degree=self.lower_lie_derivative[i],
-                        lagrangian=lower_lie_derivative_lagrangian[i],
+                        lagrangian=(
+                            lower_lie_derivative_lagrangian[i]
+                            if lower_lie_derivative_lagrangian is not None
+                            else None
+                            ),
                     )
                     for i in range(len(self.lower_lie_derivative))
                 ]
@@ -1089,6 +1092,7 @@ class CompatibleClfCbf:
         u_extreme_rays: Optional[np.ndarray] = None,
         num_cbf: int = 1,
         high_order_cbf: bool = False,
+        relative_degrees: Optional[List[int]] = None,
         with_clf: bool = True,
         use_y_squared: bool = True,
         state_eq_constraints: Optional[np.ndarray] = None
@@ -1188,6 +1192,13 @@ class CompatibleClfCbf:
         self.use_y_squared = use_y_squared
         self.num_cbf = num_cbf
         self.high_order_cbf = high_order_cbf
+        if high_order_cbf:
+            assert relative_degrees is not None
+            assert len(relative_degrees) == num_cbf
+            self.relative_degrees = relative_degrees
+        else:
+            assert relative_degrees is None
+            self.relative_degrees = None
         y_size = (
             self.num_cbf
             + (1 if self.with_clf else 0)
@@ -1377,9 +1388,7 @@ class CompatibleClfCbf:
             V=V,
             h=h,
             kappa_V=kappa_V,
-            kappa_h=kappa_h,
-            high_order_kappah=None,
-            relative_degrees=None,
+            kappa_h=kappa_h
         )
         if self.u_vertices is not None or self.u_extreme_rays is not None:
             assert isinstance(lagrangians, CompatibleWVrepLagrangians)
@@ -1390,6 +1399,7 @@ class CompatibleClfCbf:
                 xi=xi,
                 lambda_mat=lambda_mat,
                 lagrangians=lagrangians,
+                kappa_h=kappa_h,
                 barrier_eps=barrier_eps,
                 local_clf=local_clf,
                 sos_type=compatible_sos_type,
@@ -1403,6 +1413,7 @@ class CompatibleClfCbf:
                 xi=xi,
                 lambda_mat=lambda_mat,
                 lagrangians=lagrangians,
+                kappa_h=kappa_h,
                 barrier_eps=barrier_eps,
                 local_clf=local_clf,
                 sos_type=compatible_sos_type,
@@ -1521,7 +1532,8 @@ class CompatibleClfCbf:
             )
         elif compatible_states_options is not None:
             self._add_compatible_states_options(
-                prog, V, h, compatible_states_options, high_order_kappah=None
+                prog, V, h, compatible_states_options, 
+                high_order_kappah=(kappa_h if self.high_order_cbf else None),
             )
 
         result = solve_with_id(
@@ -1925,8 +1937,6 @@ class CompatibleClfCbf:
         h: np.ndarray,
         kappa_V: Optional[float],
         kappa_h: Optional[np.ndarray],
-        high_order_kappah: Optional[np.ndarray],
-        relative_degrees: Optional[List[int]],
     ) -> Tuple[np.ndarray, np.ndarray]:
         """
         Compute
@@ -1962,16 +1972,10 @@ class CompatibleClfCbf:
         """
         # function input check:
         assert h.shape[0] == self.num_cbf
-        if high_order_kappah is not None:
-            assert self.high_order_cbf
-            assert relative_degrees is not None
-            assert len(high_order_kappah) == self.num_cbf
-            assert len(relative_degrees) == self.num_cbf
-        else:
-            assert (
-                kappa_h is not None
-                ), "kappa_h and high_order_kappah should not be both none"
-            assert len(kappa_h) == self.num_cbf
+        if self.high_order_cbf:
+            assert self.relative_degrees is not None
+            assert len(kappa_h.shape) == 2
+            assert kappa_h.shape[0] == self.num_cbf
         if self.with_clf:
             assert V is not None
             assert isinstance(V, sym.Polynomial)
@@ -1988,12 +1992,12 @@ class CompatibleClfCbf:
         xi = np.empty((num_rows,), dtype=object)
 
         # (1) Loading CBFs or HOCBFs constraints:
-        if high_order_kappah is not None:
+        if self.high_order_cbf:
             for i in range(self.num_cbf):
                 current_cbf = h[i]
-                current_r = relative_degrees[i]
+                current_r = self.relative_degrees[i]
                 # xi part
-                beta_vector = elementary_symmetric_polynomials(high_order_kappah[i])
+                beta_vector = elementary_symmetric_polynomials(kappa_h[i])
                 lie_derivative_vector = np.empty(
                     shape=(current_r+1,), dtype=sym.Polynomial
                     )
@@ -2048,6 +2052,7 @@ class CompatibleClfCbf:
         xi: np.ndarray,
         lambda_mat: np.ndarray,
         lagrangians: CompatibleLagrangians,
+        kappa_h: Optional[np.ndarray],
         barrier_eps: Optional[np.ndarray],
         local_clf: bool,
         sos_type=solvers.MathematicalProgram.NonnegativePolynomial.kSos,
@@ -2074,6 +2079,9 @@ class CompatibleClfCbf:
         To certify the emptiness of the set in (2), we can use the sufficient condition
         -1 - s₀(x, y)ᵀ Λ(x)ᵀy² - s₁(x, y)(ξ(x)ᵀy²+1) - s₃(x, y)(1 − V) - s₄(x, y)ᵀ(h(x)+ε) is sos                     (4)
         s₃(x, y), s₄(x, y) are all sos.
+
+        If the CBF is HOCBF, then we also need to extend some terms in the sos polynomial condition (4):
+        -1 - s₀(x, y)ᵀ Λ(x)ᵀy² - s₁(x, y)(ξ(x)ᵀy²+1) - s₃(x, y)(1 − V) - s₄(x, y)ᵀ(h(x)+ε) - s₅(x, y)ᵀPhi[1:r-1]  is sos
 
         Note that we do NOT add the constraint
         s₂(x, y), s₃(x, y), s₄(x, y) are all sos.
@@ -2119,6 +2127,22 @@ class CompatibleClfCbf:
             assert lagrangians.h_plus_eps is not None
             poly -= lagrangians.h_plus_eps.dot(barrier_eps + h)
 
+        # if the CBF is HOCBF, compute s₅(x, y)ᵀPhi[1:r-1]:
+        if lagrangians.lower_lie_derivative is not None:
+            assert len(lagrangians.lower_lie_derivative) == self.num_cbf
+            assert len(kappa_h.shape) == 2
+            assert self.relative_degrees is not None 
+            for i in range(self.num_cbf):
+                lower_lie_derivative_polynomials = lower_lie_derivatives(
+                    poly=h[i], 
+                    vector_field=self.f, 
+                    variables=self.x,
+                    relative_degree=self.relative_degrees[i],
+                    betas=kappa_h[i]
+                )
+                poly -= lagrangians.lower_lie_derivative[i].dot(lower_lie_derivative_polynomials)
+                
+        # if we also have state equation constraints.
         if self.state_eq_constraints is not None:
             assert lagrangians.state_eq_constraints is not None
             poly -= lagrangians.state_eq_constraints.dot(self.state_eq_constraints)
@@ -2135,6 +2159,7 @@ class CompatibleClfCbf:
         xi: np.ndarray,
         lambda_mat: np.ndarray,
         lagrangians: CompatibleWVrepLagrangians,
+        kappa_h: Optional[np.ndarray],
         barrier_eps: Optional[np.ndarray],
         local_clf: bool,
         sos_type=solvers.MathematicalProgram.NonnegativePolynomial.kSos,
@@ -2191,6 +2216,20 @@ class CompatibleClfCbf:
 
         poly -= lagrangians.h_plus_eps.dot(h + barrier_eps)
 
+        # if the CBF is HOCBF, compute s₅(x, y)ᵀPhi[1:r-1]:
+        if lagrangians.lower_lie_derivative is not None:
+            assert len(lagrangians.lower_lie_derivative) == self.num_cbf
+            for i in range(self.num_cbf):
+                lower_lie_derivative_polynomials = lower_lie_derivatives(
+                    poly=h[i], 
+                    vector_field=self.f, 
+                    variables=self.x,
+                    relative_degree=self.relative_degrees[i],
+                    betas=kappa_h[i]
+                )
+                poly -= lagrangians.lower_lie_derivative[i].dot(lower_lie_derivative_polynomials)
+
+        # if we also have state equation constraints:
         if self.state_eq_constraints is not None:
             assert lagrangians.state_eq_constraints is not None
             poly -= lagrangians.state_eq_constraints.dot(self.state_eq_constraints)
@@ -2395,9 +2434,7 @@ class CompatibleClfCbf:
             V=V,
             h=h,
             kappa_V=kappa_V,
-            kappa_h=kappa_h,
-            high_order_kappah=None,
-            relative_degrees=None,
+            kappa_h=kappa_h
         )
 
         if self.u_vertices is not None or self.u_extreme_rays is not None:
@@ -2409,6 +2446,7 @@ class CompatibleClfCbf:
                 xi=xi,
                 lambda_mat=lambda_mat,
                 lagrangians=compatible_lagrangians_new,
+                kappa_h=kappa_h,
                 barrier_eps=barrier_eps,
                 local_clf=local_clf,
                 sos_type=compatible_sos_type,
@@ -2422,6 +2460,7 @@ class CompatibleClfCbf:
                 xi=xi,
                 lambda_mat=lambda_mat,
                 lagrangians=compatible_lagrangians_new,
+                kappa_h=kappa_h,
                 barrier_eps=barrier_eps,
                 local_clf=local_clf,
                 sos_type=compatible_sos_type,
@@ -2595,9 +2634,12 @@ class CompatibleClfCbf:
         compatible_states_options: CompatibleStatesOptions,
         # set the following arguments for HOCBFs:
         high_order_kappah: Optional[List[List[float]]],
-    ):
-        if high_order_kappah is not None:
+    ):  
+        if self.relative_degrees is not None:
+            assert high_order_kappah is not None
             assert len(high_order_kappah) == len(h)
+        else:
+            assert high_order_kappah is None
         compatible_states_options.add_cost(
             prog=prog,
             x=self.x,

--- a/compatible_clf_cbf/clf_cbf.py
+++ b/compatible_clf_cbf/clf_cbf.py
@@ -1052,8 +1052,8 @@ class CompatibleClfCbf:
     the entire space.
     By Farkas lemma, this is equivalent to the following set being empty
 
-    {(x, y) | [y(0)]ᵀ*[-∂h/∂x*g(x)] = 0, [y(0)]ᵀ*[ ∂h/∂x*f(x)+κ_h*h(x)] = -1, y>=0}        (1)
-              [y(1)]  [ ∂V/∂x*g(x)]      [y(1)]  [-∂V/∂x*f(x)-κ_V*V(x)]                       (1)
+    {(x, y) | [y(0)]ᵀ*[-∂h/∂x*g(x)] = 0, [y(0)]ᵀ*[ ∂h/∂x*f(x)+κ_h*h(x)] = -1, y>=0} (1)
+              [y(1)]  [ ∂V/∂x*g(x)]      [y(1)]  [-∂V/∂x*f(x)-κ_V*V(x)]
 
     We can then use Positivstellensatz to certify the emptiness of this set.
 
@@ -1066,7 +1066,7 @@ class CompatibleClfCbf:
        there exists u in the polyhedron satisfying the CLF and CBF condition,
        iff the following set is empty
 
-       {(x, y) | yᵀ * [-∂h/∂x*g(x)] = 0, yᵀ * [ ∂h/∂x*f(x)+κ_h*h(x)] = -1 }                   (2)
+       {(x, y) | yᵀ * [-∂h/∂x*g(x)] = 0, yᵀ * [ ∂h/∂x*f(x)+κ_h*h(x)] = -1 }         (2)
                       [ ∂V/∂x*g(x)]           [-∂V/∂x*f(x)-κ_V*V(x)]
                       [         Au]           [                 bu ]
        Namely we increase the dimensionality of y and append the equality
@@ -1078,7 +1078,16 @@ class CompatibleClfCbf:
        v¹, v², ..., vⁿ are the extreme rays of the polyhedron, then we need to
        certify that this set in (1) intersects with the polyhedron 𝒰, which can
        also be done by Positivstellensatz.
-    """  # noqa E501
+
+    If the CBF has high relative degrees. The set (2) above would be:
+        {(x, y) | yᵀ * [-Lfʳ⁻¹Lgh(x)] = 0, yᵀ *[ κ_hᵀγ(x)           ] = -1 }        (3)
+                       [ ∂V/∂x*g(x)]           [-∂V/∂x*f(x)-κ_V*V(x)]
+                       [         Au]           [                 bu ]
+    where γ(x) = [Lfʳh(x), Lfʳ⁻¹h(x), ..., Lfh(x), h(x)]ᵀ and κ_h should be a
+    vector of constants in this case. (See Appendix A of the Journal paper)
+    """
+
+    # noqa E501
 
     def __init__(
         self,
@@ -1130,6 +1139,13 @@ class CompatibleClfCbf:
           num_cbf: int
             The number of CBF functions. We require these CBF functions to be
             compatible in the intersection of their 0-superlevel-set.
+          high_order_cbf: bool
+            This term should be true if all CBFs are high relative degrees. In such case the set
+            (3) above should be empty.
+          relative_degrees: Optional[List[int]]
+            This term should be None if the CBFs are only with relative degree 1.
+            Otherwise we should use the list of integers to present the relative degrees of CBFs.
+            The length of this list should be equal to num_cbf.
           with_clf: bool
             Whether to certify or search for CLF. If set to False, then we will
             certify or search multiple compatible CBFs without CLF.
@@ -1348,7 +1364,7 @@ class CompatibleClfCbf:
         V: Optional[sym.Polynomial],
         h: np.ndarray,
         kappa_V: Optional[float],
-        kappa_h: np.ndarray,
+        kappa_h: Tuple[np.ndarray, List[List[float]]],
         lagrangian_degrees: Union[
             CompatibleLagrangianDegrees, CompatibleWVrepLagrangianDegrees
         ],
@@ -1398,7 +1414,7 @@ class CompatibleClfCbf:
                 xi=xi,
                 lambda_mat=lambda_mat,
                 lagrangians=lagrangians,
-                kappa_h=kappa_h,
+                high_order_kappa_h=(kappa_h if self.high_order_cbf else None),
                 barrier_eps=barrier_eps,
                 local_clf=local_clf,
                 sos_type=compatible_sos_type,
@@ -1412,7 +1428,7 @@ class CompatibleClfCbf:
                 xi=xi,
                 lambda_mat=lambda_mat,
                 lagrangians=lagrangians,
-                kappa_h=kappa_h,
+                high_order_kappa_h=(kappa_h if self.high_order_cbf else None),
                 barrier_eps=barrier_eps,
                 local_clf=local_clf,
                 sos_type=compatible_sos_type,
@@ -1424,7 +1440,7 @@ class CompatibleClfCbf:
         V: Optional[sym.Polynomial],
         h: np.ndarray,
         kappa_V: Optional[float],
-        kappa_h: np.ndarray,
+        kappa_h: Tuple[np.ndarray, List[List[float]]],
         barrier_eps: np.ndarray,
         compatible_lagrangian_degrees: Union[
             CompatibleLagrangianDegrees, CompatibleWVrepLagrangianDegrees
@@ -1485,7 +1501,7 @@ class CompatibleClfCbf:
         cbf_degrees: List[int],
         x_equilibrium: Optional[np.ndarray],
         kappa_V: Optional[float],
-        kappa_h: np.ndarray,
+        kappa_h: Tuple[np.ndarray, List[List[float]]],
         barrier_eps: np.ndarray,
         *,
         ellipsoid_inner: Optional[ellipsoid_utils.Ellipsoid] = None,
@@ -1690,7 +1706,7 @@ class CompatibleClfCbf:
         ],
         safety_sets_lagrangian_degrees: SafetySetLagrangianDegrees,
         kappa_V: Optional[float],
-        kappa_h: np.ndarray,
+        kappa_h: Tuple[float, List[List[float]]],
         barrier_eps: np.ndarray,
         x_equilibrium: np.ndarray,
         clf_degree: Optional[int],
@@ -1938,7 +1954,7 @@ class CompatibleClfCbf:
         V: Optional[sym.Polynomial],
         h: np.ndarray,
         kappa_V: Optional[float],
-        kappa_h: Optional[np.ndarray],
+        kappa_h: Tuple[np.ndarray, List[List[float]]],
     ) -> Tuple[np.ndarray, np.ndarray]:
         """
         Compute
@@ -1969,15 +1985,19 @@ class CompatibleClfCbf:
           h: An array of CBFs. h[i] is the CBF for the i'th unsafe region.
           kappa_V: κ_V in the documentation above.
           kappa_h: κ_h in the documentation above. kappa_h[i] is the kappa for h[i].
+                if the CBFs are HOCBFs, then each kappa_h[i] should be a List of floats
         Returns:
           (xi, lambda_mat) ξ(x) and Λ(x) in the documentation above.
         """
         # function input check:
         assert h.shape[0] == self.num_cbf
         if self.high_order_cbf:
+            assert isinstance(kappa_h, List)
             assert self.relative_degrees is not None
-            assert len(kappa_h.shape) == 2
-            assert kappa_h.shape[0] == self.num_cbf
+            assert len(kappa_h) == self.num_cbf
+        else:
+            assert isinstance(kappa_h, np.ndarray)
+            assert kappa_h.shape == (self.num_cbf,)
         if self.with_clf:
             assert V is not None
             assert isinstance(V, sym.Polynomial)
@@ -2053,7 +2073,7 @@ class CompatibleClfCbf:
         xi: np.ndarray,
         lambda_mat: np.ndarray,
         lagrangians: CompatibleLagrangians,
-        kappa_h: Optional[np.ndarray],
+        high_order_kappa_h: Optional[List[List[float]]],
         barrier_eps: Optional[np.ndarray],
         local_clf: bool,
         sos_type=solvers.MathematicalProgram.NonnegativePolynomial.kSos,
@@ -2087,6 +2107,10 @@ class CompatibleClfCbf:
         Note that we do NOT add the constraint
         s₂(x, y), s₃(x, y), s₄(x, y) are all sos.
         in this function. The user should add this constraint separately.
+
+        if the CBFs are HOCBFs, this function still needs all high_order_kappa_h as kappa_h for each HOCBFs.
+        But if the CBFs are just relative degree 1, then we don't need the high_order_kappa_h, and the kappa_h constant
+        is already included in the xi vector.
 
         Returns:
           poly: The polynomial on the left hand side of equation (3) or (4).
@@ -2128,18 +2152,19 @@ class CompatibleClfCbf:
             assert lagrangians.h_plus_eps is not None
             poly -= lagrangians.h_plus_eps.dot(barrier_eps + h)
 
-        # if the CBF is HOCBF, compute s₅(x, y)ᵀPhi[1:r-1]:
+        # if the CBF is HOCBF, compute s₅(x, y)ᵀPhi[1:r-1]
         if lagrangians.lower_lie_derivative is not None:
+            assert high_order_kappa_h is not None
             assert len(lagrangians.lower_lie_derivative) == self.num_cbf
-            assert len(kappa_h.shape) == 2
             assert self.relative_degrees is not None
             for i in range(self.num_cbf):
+                assert len(high_order_kappa_h[i]) == self.relative_degrees[i]
                 lower_lie_derivative_polynomials = lower_lie_derivatives(
                     poly=h[i],
                     vector_field=self.f,
                     variables=self.x,
                     relative_degree=self.relative_degrees[i],
-                    betas=kappa_h[i],
+                    betas=high_order_kappa_h[i],
                 )
                 poly -= lagrangians.lower_lie_derivative[i].dot(
                     lower_lie_derivative_polynomials
@@ -2162,7 +2187,7 @@ class CompatibleClfCbf:
         xi: np.ndarray,
         lambda_mat: np.ndarray,
         lagrangians: CompatibleWVrepLagrangians,
-        kappa_h: Optional[np.ndarray],
+        high_order_kappa_h: Optional[List[List[float]]],
         barrier_eps: Optional[np.ndarray],
         local_clf: bool,
         sos_type=solvers.MathematicalProgram.NonnegativePolynomial.kSos,
@@ -2221,14 +2246,16 @@ class CompatibleClfCbf:
 
         # if the CBF is HOCBF, compute s₅(x, y)ᵀPhi[1:r-1]:
         if lagrangians.lower_lie_derivative is not None:
+            assert high_order_kappa_h is not None
             assert len(lagrangians.lower_lie_derivative) == self.num_cbf
             for i in range(self.num_cbf):
+                assert len(high_order_kappa_h[i]) == self.relative_degrees[i]
                 lower_lie_derivative_polynomials = lower_lie_derivatives(
                     poly=h[i],
                     vector_field=self.f,
                     variables=self.x,
                     relative_degree=self.relative_degrees[i],
-                    betas=kappa_h[i],
+                    betas=high_order_kappa_h[i],
                 )
                 poly -= lagrangians.lower_lie_derivative[i].dot(
                     lower_lie_derivative_polynomials
@@ -2329,7 +2356,7 @@ class CompatibleClfCbf:
         cbf_degrees: List[int],
         x_equilibrium: Optional[np.ndarray],
         kappa_V: Optional[float],
-        kappa_h: np.ndarray,
+        kappa_h: Tuple[np.ndarray, List[List[float]]],
         barrier_eps: np.ndarray,
         local_clf: bool = True,
         compatible_sos_type=solvers.MathematicalProgram.NonnegativePolynomial.kSos,
@@ -2434,7 +2461,6 @@ class CompatibleClfCbf:
                 rho_minus_V_lagrangian=compatible_lagrangians.rho_minus_V,
                 h_plus_eps_lagrangian=compatible_lagrangians.h_plus_eps,
             )
-
         xi, lambda_mat = self._calc_xi_Lambda(
             V=V, h=h, kappa_V=kappa_V, kappa_h=kappa_h
         )
@@ -2448,7 +2474,7 @@ class CompatibleClfCbf:
                 xi=xi,
                 lambda_mat=lambda_mat,
                 lagrangians=compatible_lagrangians_new,
-                kappa_h=kappa_h,
+                high_order_kappa_h=(kappa_h if self.high_order_cbf else None),
                 barrier_eps=barrier_eps,
                 local_clf=local_clf,
                 sos_type=compatible_sos_type,
@@ -2462,7 +2488,7 @@ class CompatibleClfCbf:
                 xi=xi,
                 lambda_mat=lambda_mat,
                 lagrangians=compatible_lagrangians_new,
-                kappa_h=kappa_h,
+                high_order_kappa_h=(kappa_h if self.high_order_cbf else None),
                 barrier_eps=barrier_eps,
                 local_clf=local_clf,
                 sos_type=compatible_sos_type,

--- a/compatible_clf_cbf/clf_cbf.py
+++ b/compatible_clf_cbf/clf_cbf.py
@@ -2103,7 +2103,7 @@ class CompatibleClfCbf:
 
         If the CBF is HOCBF, then we also need to extend some terms in the sos polynomial condition (4):
         -1 - s₀(x, y)ᵀ Λ(x)ᵀy² - s₁(x, y)(ξ(x)ᵀy²+1) - s₃(x, y)(1 − V) - s₄(x, y)ᵀ(h(x)+ε) - s₅(x, y)ᵀPhi[1:r-1]  is sos
-                                                                                                                    
+
                                                                                                                       (5)
         Note that we do NOT add the constraint
         s₂(x, y), s₃(x, y), s₄(x, y) are all sos.
@@ -2115,7 +2115,7 @@ class CompatibleClfCbf:
 
         If the CBF is h(x) and the relative degree is 1, then the compatibility SOS constraint is shown as (3) or (4).
         We don't need kappa_h and kappa_V in this case since they are already included in the xi vector.
-        
+
         However, if the CBF is h(x) and the relative degree is 2, we will then have the following relationship:
         Phi_0(x) = h(x)
         Phi_1(x) = Lfh(x) + kappa1_h * h(x)

--- a/compatible_clf_cbf/clf_cbf.py
+++ b/compatible_clf_cbf/clf_cbf.py
@@ -331,9 +331,11 @@ class CompatibleLagrangianDegrees:
                     sos_type,
                     is_sos=True,
                     degree=self.lower_lie_derivative[i],
-                    lagrangian=(lower_lie_derivative_lagrangian[i]
-                                if lower_lie_derivative_lagrangian is not None
-                                else None),
+                    lagrangian=(
+                        lower_lie_derivative_lagrangian[i]
+                        if lower_lie_derivative_lagrangian is not None
+                        else None
+                    ),
                 )
                 for i in range(len(self.lower_lie_derivative))
             ]
@@ -550,7 +552,7 @@ class CompatibleWVrepLagrangianDegrees:
                             lower_lie_derivative_lagrangian[i]
                             if lower_lie_derivative_lagrangian is not None
                             else None
-                            ),
+                        ),
                     )
                     for i in range(len(self.lower_lie_derivative))
                 ]
@@ -1095,7 +1097,7 @@ class CompatibleClfCbf:
         relative_degrees: Optional[List[int]] = None,
         with_clf: bool = True,
         use_y_squared: bool = True,
-        state_eq_constraints: Optional[np.ndarray] = None
+        state_eq_constraints: Optional[np.ndarray] = None,
     ):
         """
         Args:
@@ -1163,8 +1165,8 @@ class CompatibleClfCbf:
         self.x_set: sym.Variables = sym.Variables(x)
         check_array_of_polynomials(f, self.x_set)
         check_array_of_polynomials(g, self.x_set)
-        assert (
-            (exclude_sets != []) or (within_set is not None)
+        assert (exclude_sets != []) or (
+            within_set is not None
         ), "The exclude_sets and within_set cannot be both None"
         self.exclude_sets = exclude_sets
         self.within_set = within_set
@@ -1385,10 +1387,7 @@ class CompatibleClfCbf:
         )
 
         xi, lambda_mat = self._calc_xi_Lambda(
-            V=V,
-            h=h,
-            kappa_V=kappa_V,
-            kappa_h=kappa_h
+            V=V, h=h, kappa_V=kappa_V, kappa_h=kappa_h
         )
         if self.u_vertices is not None or self.u_extreme_rays is not None:
             assert isinstance(lagrangians, CompatibleWVrepLagrangians)
@@ -1532,7 +1531,10 @@ class CompatibleClfCbf:
             )
         elif compatible_states_options is not None:
             self._add_compatible_states_options(
-                prog, V, h, compatible_states_options, 
+                prog,
+                V,
+                h,
+                compatible_states_options,
                 high_order_kappah=(kappa_h if self.high_order_cbf else None),
             )
 
@@ -1999,15 +2001,15 @@ class CompatibleClfCbf:
                 # xi part
                 beta_vector = elementary_symmetric_polynomials(kappa_h[i])
                 lie_derivative_vector = np.empty(
-                    shape=(current_r+1,), dtype=sym.Polynomial
-                    )
+                    shape=(current_r + 1,), dtype=sym.Polynomial
+                )
                 lie_derivative_vector[-1] = current_cbf
                 for j in range(current_r, 0, -1):
-                    lie_derivative_vector[j-1] = lie_derivative(
+                    lie_derivative_vector[j - 1] = lie_derivative(
                         poly=lie_derivative_vector[j],
                         vector_feild=self.f,
                         variables=self.x,
-                        pow=1
+                        pow=1,
                     )
                 xi_element = np.dot(lie_derivative_vector, beta_vector)
                 xi[i] = xi_element
@@ -2017,14 +2019,13 @@ class CompatibleClfCbf:
                     poly=lie_derivative_vector[1],
                     vector_feild=self.g,
                     variables=self.x,
-                    pow=1
-                    )
+                    pow=1,
+                )
                 lambda_element = -LfLgb
                 lambda_mat[i] = lambda_element
         else:
             dhdx = np.concatenate(
-                [h[i].Jacobian(self.x).reshape((1, -1)) for i in range(h.size)],
-                axis=0
+                [h[i].Jacobian(self.x).reshape((1, -1)) for i in range(h.size)], axis=0
             )
             lambda_mat[: self.num_cbf] = -dhdx @ self.g
             xi[: self.num_cbf] = dhdx @ self.f + kappa_h * h
@@ -2131,17 +2132,19 @@ class CompatibleClfCbf:
         if lagrangians.lower_lie_derivative is not None:
             assert len(lagrangians.lower_lie_derivative) == self.num_cbf
             assert len(kappa_h.shape) == 2
-            assert self.relative_degrees is not None 
+            assert self.relative_degrees is not None
             for i in range(self.num_cbf):
                 lower_lie_derivative_polynomials = lower_lie_derivatives(
-                    poly=h[i], 
-                    vector_field=self.f, 
+                    poly=h[i],
+                    vector_field=self.f,
                     variables=self.x,
                     relative_degree=self.relative_degrees[i],
-                    betas=kappa_h[i]
+                    betas=kappa_h[i],
                 )
-                poly -= lagrangians.lower_lie_derivative[i].dot(lower_lie_derivative_polynomials)
-                
+                poly -= lagrangians.lower_lie_derivative[i].dot(
+                    lower_lie_derivative_polynomials
+                )
+
         # if we also have state equation constraints.
         if self.state_eq_constraints is not None:
             assert lagrangians.state_eq_constraints is not None
@@ -2221,13 +2224,15 @@ class CompatibleClfCbf:
             assert len(lagrangians.lower_lie_derivative) == self.num_cbf
             for i in range(self.num_cbf):
                 lower_lie_derivative_polynomials = lower_lie_derivatives(
-                    poly=h[i], 
-                    vector_field=self.f, 
+                    poly=h[i],
+                    vector_field=self.f,
                     variables=self.x,
                     relative_degree=self.relative_degrees[i],
-                    betas=kappa_h[i]
+                    betas=kappa_h[i],
                 )
-                poly -= lagrangians.lower_lie_derivative[i].dot(lower_lie_derivative_polynomials)
+                poly -= lagrangians.lower_lie_derivative[i].dot(
+                    lower_lie_derivative_polynomials
+                )
 
         # if we also have state equation constraints:
         if self.state_eq_constraints is not None:
@@ -2431,10 +2436,7 @@ class CompatibleClfCbf:
             )
 
         xi, lambda_mat = self._calc_xi_Lambda(
-            V=V,
-            h=h,
-            kappa_V=kappa_V,
-            kappa_h=kappa_h
+            V=V, h=h, kappa_V=kappa_V, kappa_h=kappa_h
         )
 
         if self.u_vertices is not None or self.u_extreme_rays is not None:
@@ -2634,7 +2636,7 @@ class CompatibleClfCbf:
         compatible_states_options: CompatibleStatesOptions,
         # set the following arguments for HOCBFs:
         high_order_kappah: Optional[List[List[float]]],
-    ):  
+    ):
         if self.relative_degrees is not None:
             assert high_order_kappah is not None
             assert len(high_order_kappah) == len(h)

--- a/compatible_clf_cbf/clf_cbf.py
+++ b/compatible_clf_cbf/clf_cbf.py
@@ -1052,9 +1052,9 @@ class CompatibleClfCbf:
     the entire space.
     By Farkas lemma, this is equivalent to the following set being empty
 
-    {(x, y) | [y(0)]ᵀ*[-∂h/∂x*g(x)] = 0, [y(0)]ᵀ*[ ∂h/∂x*f(x)+κ_h*h(x)] = -1, y>=0} (1)
+    {(x, y) | [y(0)]ᵀ*[-∂h/∂x*g(x)] = 0, [y(0)]ᵀ*[ ∂h/∂x*f(x)+κ_h*h(x)] = -1, y >= 0 }
               [y(1)]  [ ∂V/∂x*g(x)]      [y(1)]  [-∂V/∂x*f(x)-κ_V*V(x)]
-
+                                                                                    (1)
     We can then use Positivstellensatz to certify the emptiness of this set.
 
     The same math applies to multiple CBFs, or when u is constrained within a
@@ -1414,7 +1414,7 @@ class CompatibleClfCbf:
                 xi=xi,
                 lambda_mat=lambda_mat,
                 lagrangians=lagrangians,
-                high_order_kappa_h=(kappa_h if self.high_order_cbf else None),
+                kappa_h=(kappa_h if self.high_order_cbf else None),
                 barrier_eps=barrier_eps,
                 local_clf=local_clf,
                 sos_type=compatible_sos_type,
@@ -1428,7 +1428,7 @@ class CompatibleClfCbf:
                 xi=xi,
                 lambda_mat=lambda_mat,
                 lagrangians=lagrangians,
-                high_order_kappa_h=(kappa_h if self.high_order_cbf else None),
+                kappa_h=(kappa_h if self.high_order_cbf else None),
                 barrier_eps=barrier_eps,
                 local_clf=local_clf,
                 sos_type=compatible_sos_type,
@@ -2073,7 +2073,7 @@ class CompatibleClfCbf:
         xi: np.ndarray,
         lambda_mat: np.ndarray,
         lagrangians: CompatibleLagrangians,
-        high_order_kappa_h: Optional[List[List[float]]],
+        kappa_h: Optional[List[List[float]]],
         barrier_eps: Optional[np.ndarray],
         local_clf: bool,
         sos_type=solvers.MathematicalProgram.NonnegativePolynomial.kSos,
@@ -2103,14 +2103,30 @@ class CompatibleClfCbf:
 
         If the CBF is HOCBF, then we also need to extend some terms in the sos polynomial condition (4):
         -1 - s₀(x, y)ᵀ Λ(x)ᵀy² - s₁(x, y)(ξ(x)ᵀy²+1) - s₃(x, y)(1 − V) - s₄(x, y)ᵀ(h(x)+ε) - s₅(x, y)ᵀPhi[1:r-1]  is sos
-
+                                                                                                                    
+                                                                                                                      (5)
         Note that we do NOT add the constraint
         s₂(x, y), s₃(x, y), s₄(x, y) are all sos.
         in this function. The user should add this constraint separately.
 
-        if the CBFs are HOCBFs, this function still needs all high_order_kappa_h as kappa_h for each HOCBFs.
-        But if the CBFs are just relative degree 1, then we don't need the high_order_kappa_h, and the kappa_h constant
-        is already included in the xi vector.
+        If the CBFs are HOCBFs, this function still needs kappa_h for construction of SOS comaptibility constraint.
+        But if the CBFs are just relative degree 1, then we don't need the kappa_h, since the kappa_h constant
+        is already included in the xi vector. Let's use a simple example to exaplain this:
+
+        If the CBF is h(x) and the relative degree is 1, then the compatibility SOS constraint is shown as (3) or (4).
+        We don't need kappa_h and kappa_V in this case since they are already included in the xi vector.
+        
+        However, if the CBF is h(x) and the relative degree is 2, we will then have the following relationship:
+        Phi_0(x) = h(x)
+        Phi_1(x) = Lfh(x) + kappa1_h * h(x)
+        Phi_2(x) = LfLgh(x)*u + Lf²h(x) + (kappa1_h + kappa2_h) * Lfh(x) + (kappa1_h * kappa2_h) * h(x)
+        We use Phi_2(x) ≥ 0 to replace the first row of xi and lambda_mat. The kappa_h now is a list of floats such that
+        kappa_h = [kappa1_h, kappa2_h]. The SOS compatibility constraint is shown as (5).
+        We can see that (5) needs Phi_1(x), hence it needs kappa_h even if xi and lambda_mat already include kappa2_h.
+
+        Hence, kappa_h is an optional parameter. If the CBFs are just relative degree 1, we can set kappa_h=None.
+        If the CBFs are HOCBFs, we need to set kappa_h as a list. Note that we may also have multiple HOCBFs,
+        so the kappa_h is assumed to be a list of list of floats.
 
         Returns:
           poly: The polynomial on the left hand side of equation (3) or (4).
@@ -2154,17 +2170,17 @@ class CompatibleClfCbf:
 
         # if the CBF is HOCBF, compute s₅(x, y)ᵀPhi[1:r-1]
         if lagrangians.lower_lie_derivative is not None:
-            assert high_order_kappa_h is not None
+            assert kappa_h is not None
             assert len(lagrangians.lower_lie_derivative) == self.num_cbf
             assert self.relative_degrees is not None
             for i in range(self.num_cbf):
-                assert len(high_order_kappa_h[i]) == self.relative_degrees[i]
+                assert len(kappa_h[i]) == self.relative_degrees[i]
                 lower_lie_derivative_polynomials = lower_lie_derivatives(
                     poly=h[i],
                     vector_field=self.f,
                     variables=self.x,
                     relative_degree=self.relative_degrees[i],
-                    betas=high_order_kappa_h[i],
+                    betas=kappa_h[i],
                 )
                 poly -= lagrangians.lower_lie_derivative[i].dot(
                     lower_lie_derivative_polynomials
@@ -2187,7 +2203,7 @@ class CompatibleClfCbf:
         xi: np.ndarray,
         lambda_mat: np.ndarray,
         lagrangians: CompatibleWVrepLagrangians,
-        high_order_kappa_h: Optional[List[List[float]]],
+        kappa_h: Optional[List[List[float]]],
         barrier_eps: Optional[np.ndarray],
         local_clf: bool,
         sos_type=solvers.MathematicalProgram.NonnegativePolynomial.kSos,
@@ -2246,16 +2262,16 @@ class CompatibleClfCbf:
 
         # if the CBF is HOCBF, compute s₅(x, y)ᵀPhi[1:r-1]:
         if lagrangians.lower_lie_derivative is not None:
-            assert high_order_kappa_h is not None
+            assert kappa_h is not None
             assert len(lagrangians.lower_lie_derivative) == self.num_cbf
             for i in range(self.num_cbf):
-                assert len(high_order_kappa_h[i]) == self.relative_degrees[i]
+                assert len(kappa_h[i]) == self.relative_degrees[i]
                 lower_lie_derivative_polynomials = lower_lie_derivatives(
                     poly=h[i],
                     vector_field=self.f,
                     variables=self.x,
                     relative_degree=self.relative_degrees[i],
-                    betas=high_order_kappa_h[i],
+                    betas=kappa_h[i],
                 )
                 poly -= lagrangians.lower_lie_derivative[i].dot(
                     lower_lie_derivative_polynomials
@@ -2474,7 +2490,7 @@ class CompatibleClfCbf:
                 xi=xi,
                 lambda_mat=lambda_mat,
                 lagrangians=compatible_lagrangians_new,
-                high_order_kappa_h=(kappa_h if self.high_order_cbf else None),
+                kappa_h=(kappa_h if self.high_order_cbf else None),
                 barrier_eps=barrier_eps,
                 local_clf=local_clf,
                 sos_type=compatible_sos_type,
@@ -2488,7 +2504,7 @@ class CompatibleClfCbf:
                 xi=xi,
                 lambda_mat=lambda_mat,
                 lagrangians=compatible_lagrangians_new,
-                high_order_kappa_h=(kappa_h if self.high_order_cbf else None),
+                kappa_h=(kappa_h if self.high_order_cbf else None),
                 barrier_eps=barrier_eps,
                 local_clf=local_clf,
                 sos_type=compatible_sos_type,

--- a/compatible_clf_cbf/clf_cbf.py
+++ b/compatible_clf_cbf/clf_cbf.py
@@ -1364,7 +1364,7 @@ class CompatibleClfCbf:
         V: Optional[sym.Polynomial],
         h: np.ndarray,
         kappa_V: Optional[float],
-        kappa_h: Tuple[np.ndarray, List[List[float]]],
+        kappa_h: Union[np.ndarray, List[List[float]]],
         lagrangian_degrees: Union[
             CompatibleLagrangianDegrees, CompatibleWVrepLagrangianDegrees
         ],
@@ -1440,7 +1440,7 @@ class CompatibleClfCbf:
         V: Optional[sym.Polynomial],
         h: np.ndarray,
         kappa_V: Optional[float],
-        kappa_h: Tuple[np.ndarray, List[List[float]]],
+        kappa_h: Union[np.ndarray, List[List[float]]],
         barrier_eps: np.ndarray,
         compatible_lagrangian_degrees: Union[
             CompatibleLagrangianDegrees, CompatibleWVrepLagrangianDegrees
@@ -1501,7 +1501,7 @@ class CompatibleClfCbf:
         cbf_degrees: List[int],
         x_equilibrium: Optional[np.ndarray],
         kappa_V: Optional[float],
-        kappa_h: Tuple[np.ndarray, List[List[float]]],
+        kappa_h: Union[np.ndarray, List[List[float]]],
         barrier_eps: np.ndarray,
         *,
         ellipsoid_inner: Optional[ellipsoid_utils.Ellipsoid] = None,
@@ -1706,7 +1706,7 @@ class CompatibleClfCbf:
         ],
         safety_sets_lagrangian_degrees: SafetySetLagrangianDegrees,
         kappa_V: Optional[float],
-        kappa_h: Tuple[float, List[List[float]]],
+        kappa_h: Union[np.ndarray, List[List[float]]],
         barrier_eps: np.ndarray,
         x_equilibrium: np.ndarray,
         clf_degree: Optional[int],
@@ -1954,7 +1954,7 @@ class CompatibleClfCbf:
         V: Optional[sym.Polynomial],
         h: np.ndarray,
         kappa_V: Optional[float],
-        kappa_h: Tuple[np.ndarray, List[List[float]]],
+        kappa_h: Union[np.ndarray, List[List[float]]],
     ) -> Tuple[np.ndarray, np.ndarray]:
         """
         Compute
@@ -2356,7 +2356,7 @@ class CompatibleClfCbf:
         cbf_degrees: List[int],
         x_equilibrium: Optional[np.ndarray],
         kappa_V: Optional[float],
-        kappa_h: Tuple[np.ndarray, List[List[float]]],
+        kappa_h: Union[np.ndarray, List[List[float]]],
         barrier_eps: np.ndarray,
         local_clf: bool = True,
         compatible_sos_type=solvers.MathematicalProgram.NonnegativePolynomial.kSos,

--- a/examples/nonlinear_toy/demo_trigpoly.py
+++ b/examples/nonlinear_toy/demo_trigpoly.py
@@ -373,7 +373,7 @@ def main():
 
     V, h = search(use_v_rep=False, unit_test_flag=args.unit_test)
     if not args.unit_test:
-        # visualize()
+        visualize()
         pass
 
 

--- a/examples/nonlinear_toy/synthesize_demo.py
+++ b/examples/nonlinear_toy/synthesize_demo.py
@@ -72,6 +72,10 @@ def main(with_u_bound: bool):
         h_anchor_bounds=[(np.array([0]), np.array([0.1]))],
         weight_V=1.0,
         weight_h=np.array([1.0]),
+        relative_degrees=None,
+        weight_lower_lie_derivatives=None,
+        V_margin=None,
+        h_margins=None,
     )
 
     solver_options = solvers.SolverOptions()

--- a/tests/test_clf_cbf.py
+++ b/tests/test_clf_cbf.py
@@ -7,6 +7,7 @@ import pytest  # noqa
 
 import pydrake.solvers as solvers
 import pydrake.symbolic as sym
+import pydrake.systems.controllers as controller
 
 import compatible_clf_cbf.ellipsoid_utils as ellipsoid_utils
 import compatible_clf_cbf.utils as utils
@@ -442,9 +443,7 @@ class TestClfCbf(object):
             V=V,
             h=h,
             kappa_V=kappa_V,
-            kappa_h=kappa_h,
-            high_order_kappah=None,
-            relative_degrees=None,
+            kappa_h=kappa_h
             )
         assert xi.shape == (1 + dut.num_cbf,)
         assert lambda_mat.shape == (1 + dut.num_cbf, dut.nu)
@@ -492,9 +491,7 @@ class TestClfCbf(object):
             V=V,
             h=h,
             kappa_V=kappa_V,
-            kappa_h=kappa_h,
-            high_order_kappah=None,
-            relative_degrees=None,
+            kappa_h=kappa_h
             )
         assert xi.shape == (dut.num_cbf,)
         assert lambda_mat.shape == (dut.num_cbf, dut.nu)
@@ -541,9 +538,7 @@ class TestClfCbf(object):
             V=V,
             h=h,
             kappa_V=kappa_V,
-            kappa_h=kappa_h,
-            high_order_kappah=None,
-            relative_degrees=None,
+            kappa_h=kappa_h
             )
 
         dVdx = V.Jacobian(self.x)
@@ -601,13 +596,13 @@ class TestClfCbf(object):
             bu=np.array([1, 1]),
             num_cbf=2,
             high_order_cbf=True,
-            with_clf=True
+            relative_degrees=[2, 2],
+            with_clf=True,
         )
         V = sym.Polynomial(x[0] ** 2 + x[1] ** 2)
         h = np.array([sym.Polynomial(1 - x[0]), sym.Polynomial(1 + x[0])])
         kappa_V = 0.01
-        high_order_kappah = [[0.1, 0.1], [0.1, 0.1]]
-        relative_degrees = [2, 2]
+        kappah = np.array([[0.1, 0.1], [0.1, 0.1]])
         # compute the expected Lambda and xi by hand:
         LfV = 2*x[0]*x[1]
         LgV = 2*x[1]
@@ -617,10 +612,10 @@ class TestClfCbf(object):
         Lf2h2 = 0
         LgLfh1 = -1
         LgLfh2 = 1
-        beta_11 = high_order_kappah[0][0]
-        beta_12 = high_order_kappah[0][1]
-        beta_21 = high_order_kappah[1][0]
-        beta_22 = high_order_kappah[1][1]
+        beta_11 = kappah[0][0]
+        beta_12 = kappah[0][1]
+        beta_21 = kappah[1][0]
+        beta_22 = kappah[1][1]
         lambda_mat_expected = np.array([
             [sym.Polynomial(-LgLfh1)],
             [sym.Polynomial(-LgLfh2)],
@@ -642,9 +637,7 @@ class TestClfCbf(object):
             V=V,
             h=h,
             kappa_V=kappa_V,
-            kappa_h=None,
-            high_order_kappah=high_order_kappah,
-            relative_degrees=relative_degrees,
+            kappa_h=kappah
         )
 
         assert xi.shape == xi_expected.shape
@@ -703,7 +696,7 @@ class TestClfCbf(object):
         prog, lagrangians = dut.construct_search_compatible_lagrangians(
             V, h, kappa_V, kappa_h, lagrangian_degrees, barrier_eps
         )
-
+    
     def test_add_compatibility_w_clf_y_squared(self):
         """
         Test _add_compatibility with CLF and use_y_squared=True
@@ -759,9 +752,7 @@ class TestClfCbf(object):
             V=V,
             h=h,
             kappa_V=kappa_V,
-            kappa_h=kappa_h,
-            high_order_kappah=None,
-            relative_degrees=None,
+            kappa_h=kappa_h
             )
 
         barrier_eps = np.array([0.01, 0.02])
@@ -772,6 +763,7 @@ class TestClfCbf(object):
             xi=xi,
             lambda_mat=lambda_mat,
             lagrangians=lagrangians,
+            kappa_h=None,
             barrier_eps=barrier_eps,
             local_clf=True,
         )
@@ -834,9 +826,7 @@ class TestClfCbf(object):
             V=V,
             h=h,
             kappa_V=kappa_V,
-            kappa_h=kappa_h,
-            high_order_kappah=None,
-            relative_degrees=None,
+            kappa_h=kappa_h
             )
         barrier_eps = np.array([0.01, 0.02])
         poly = dut._add_compatibility_w_vrep(
@@ -846,6 +836,7 @@ class TestClfCbf(object):
             xi=xi,
             lambda_mat=lambda_mat,
             lagrangians=lagrangians,
+            kappa_h=None,
             barrier_eps=barrier_eps,
             local_clf=True,
         )
@@ -916,9 +907,7 @@ class TestClfCbf(object):
             V=V,
             h=h,
             kappa_V=kappa_V,
-            kappa_h=kappa_h,
-            high_order_kappah=None,
-            relative_degrees=None,
+            kappa_h=kappa_h
             )
         barrier_eps = np.array([0.01, 0.02])
         poly = dut._add_compatibility_w_vrep(
@@ -928,6 +917,7 @@ class TestClfCbf(object):
             xi=xi,
             lambda_mat=lambda_mat,
             lagrangians=lagrangians,
+            kappa_h=None,
             barrier_eps=barrier_eps,
             local_clf=True,
         )
@@ -1883,3 +1873,218 @@ class TestCompatibleWithU:
         self.intersect_tester(
             lambda_mat, xi, u_vertices, u_extreme_rays, intersect_expected=False
         )
+
+
+class TestCLfCbfWHocbfs:
+    
+    @classmethod
+    def setup_class(cls):
+        # we use a 1D double intergrator for testing
+        cls.nx = 2
+        cls.nu = 1
+        cls.x = sym.MakeVectorContinuousVariable(cls.nx, "x")
+        cls.f = np.array([
+            sym.Polynomial(cls.x[1]),
+            sym.Polynomial(0)
+        ])
+        cls.g = np.array([
+            [sym.Polynomial(0)], 
+            [sym.Polynomial(1)]
+            ])
+        cls.exclude_sets = [
+            mut.ExcludeSet(np.array([
+                sym.Polynomial(cls.x[0] + 10),
+                sym.Polynomial(-cls.x[0] + 10)
+            ]))
+        ]
+        cls.within_set = None
+        
+        _, S = controller.LinearQuadraticRegulator(
+            A = np.array([
+                [0, 1],
+                [0, 0]
+                ]),
+            B = np.array([[0], [1]]),
+            Q = np.eye(2),
+            R = np.eye(1),
+        )
+        cls.V = sym.Polynomial(np.dot(cls.x, np.dot(S, cls.x)))
+        cls.h = np.array([
+            sym.Polynomial(cls.x[0] + 5),
+            sym.Polynomial(-cls.x[0] + 5)
+        ])
+
+        cls.kappa_V = 0.1
+        cls.kappa_h = np.array([
+            [1, 1], [1, 1]
+        ])
+        cls.relative_degrees = [2, 2]
+        cls.barrier_eps = np.array([0.01, 0.01])
+    
+    def test_add_compatibility_w_hocbf(self):
+        dut = mut.CompatibleClfCbf(
+            f=self.f,
+            g=self.g,
+            x=self.x,
+            exclude_sets=self.exclude_sets,
+            within_set=self.within_set,
+            Au=None,
+            bu=None,
+            num_cbf=2,
+            high_order_cbf=True,
+            relative_degrees=self.relative_degrees,
+            with_clf=True,
+            use_y_squared=True,
+        )
+        prog = solvers.MathematicalProgram()
+        prog.AddIndeterminates(dut.xy_set)
+
+        lagrangian_degrees = mut.CompatibleLagrangianDegrees(
+            lambda_y=[mut.XYDegree(x=2, y=0)],
+            xi_y=mut.XYDegree(x=2, y=0),
+            y=None,
+            y_cross=None,
+            rho_minus_V=mut.XYDegree(x=2, y=2),
+            h_plus_eps=[mut.XYDegree(x=2, y=2), mut.XYDegree(x=2, y=2)],
+            lower_lie_derivative=[
+                [mut.XYDegree(x=2, y=2)],
+                [mut.XYDegree(x=2, y=2)],
+                ],
+            state_eq_constraints=None,
+        )
+
+        lagrangians =lagrangian_degrees.to_lagrangians(
+            prog=prog,
+            x=dut.x_set,
+            y=dut.y_set
+        )
+
+        xi_vec, lambda_mat = dut._calc_xi_Lambda(
+            V=self.V,
+            h=self.h,
+            kappa_V=self.kappa_V,
+            kappa_h=self.kappa_h,
+        )
+
+        poly = dut._add_compatibility(
+            prog=prog,
+            V=self.V,
+            h=self.h,
+            xi=xi_vec,
+            lambda_mat=lambda_mat,
+            lagrangians=lagrangians,
+            kappa_h=self.kappa_h,
+            barrier_eps=self.barrier_eps,
+            local_clf=True,
+        )
+
+        lower_lie_derivative_polys_h0 = utils.lower_lie_derivatives(
+            poly=self.h[0],
+            vector_field=self.f,
+            variables=self.x,
+            relative_degree=self.relative_degrees[0],
+            betas=self.kappa_h[0]
+        )
+        lower_lie_derivative_polys_h1 = utils.lower_lie_derivatives(
+            poly=self.h[1],
+            vector_field=self.f,
+            variables=self.x,
+            relative_degree=self.relative_degrees[1],
+            betas=self.kappa_h[1]
+        )
+        expected_poly = (
+            -1 
+            -np.dot(lagrangians.lambda_y, np.dot(lambda_mat.T, dut.y_squared_poly))
+            -lagrangians.xi_y * (xi_vec.dot(dut.y_squared_poly) + 1)
+            -lagrangians.rho_minus_V * (1 - self.V)
+            -lagrangians.h_plus_eps.dot(self.h + self.barrier_eps)
+            -lagrangians.lower_lie_derivative[0].dot(lower_lie_derivative_polys_h0)
+            -lagrangians.lower_lie_derivative[1].dot(lower_lie_derivative_polys_h1)
+        )
+
+        assert poly.CoefficientsAlmostEqual(expected_poly, tolerance=1e-5)
+
+    def test_add_compatibility_v_rep_w_hocbf(self):
+        dut = mut.CompatibleClfCbf(
+            f=self.f,
+            g=self.g,
+            x=self.x,
+            exclude_sets=self.exclude_sets,
+            within_set=self.within_set,
+            Au=None,
+            bu=None,
+            u_vertices=np.array([[-1], [1]]),
+            u_extreme_rays=None,
+            num_cbf=2,
+            high_order_cbf=True,
+            relative_degrees=self.relative_degrees,
+            with_clf=True,
+            use_y_squared=True,
+        )
+        prog = solvers.MathematicalProgram()
+        prog.AddIndeterminates(dut.xy_set)
+
+        lagrangian_degrees = mut.CompatibleWVrepLagrangianDegrees(
+            u_vertices=[
+                mut.XYDegree(x=2, y=2) 
+                for _ in range(dut.u_vertices.shape[0])
+                ],
+            u_extreme_rays=None,
+            y=None,
+            y_cross=None,
+            rho_minus_V=mut.XYDegree(x=2, y=2),
+            h_plus_eps=[mut.XYDegree(x=2, y=4) for _ in range(self.h.size)],
+            lower_lie_derivative=[
+                [mut.XYDegree(x=2, y=2)],
+                [mut.XYDegree(x=2, y=2)],
+                ],
+            state_eq_constraints=None,
+        )
+        lagrangians = lagrangian_degrees.to_lagrangians(prog, dut.x_set, dut.y_set)
+
+        xi, lambda_mat = dut._calc_xi_Lambda(
+            V=self.V,
+            h=self.h,
+            kappa_V=self.kappa_V,
+            kappa_h=self.kappa_h
+            )
+        barrier_eps = np.array([0.01, 0.02])
+        poly = dut._add_compatibility_w_vrep(
+            prog=prog,
+            V=self.V,
+            h=self.h,
+            xi=xi,
+            lambda_mat=lambda_mat,
+            lagrangians=lagrangians,
+            kappa_h=self.kappa_h,
+            barrier_eps=barrier_eps,
+            local_clf=True,
+        )
+
+        lower_lie_derivative_polys_h0 = utils.lower_lie_derivatives(
+            poly=self.h[0],
+            vector_field=self.f,
+            variables=self.x,
+            relative_degree=self.relative_degrees[0],
+            betas=self.kappa_h[0]
+        )
+        lower_lie_derivative_polys_h1 = utils.lower_lie_derivatives(
+            poly=self.h[1],
+            vector_field=self.f,
+            variables=self.x,
+            relative_degree=self.relative_degrees[1],
+            betas=self.kappa_h[1]
+        )
+
+        expected_poly = (
+            -1
+            - lagrangians.u_vertices.dot(
+                -xi.dot(dut.y_squared_poly) + dut.y_squared_poly @ (lambda_mat @ dut.u_vertices.T) - 1
+            )
+            - lagrangians.rho_minus_V * (1 - self.V)
+            - lagrangians.h_plus_eps.dot(self.h + barrier_eps)
+            - lagrangians.lower_lie_derivative[0].dot(lower_lie_derivative_polys_h0)
+            - lagrangians.lower_lie_derivative[1].dot(lower_lie_derivative_polys_h1)
+        )
+
+        assert poly.CoefficientsAlmostEqual(expected_poly, tolerance=1e-5)

--- a/tests/test_clf_cbf.py
+++ b/tests/test_clf_cbf.py
@@ -741,7 +741,7 @@ class TestClfCbf(object):
             xi=xi,
             lambda_mat=lambda_mat,
             lagrangians=lagrangians,
-            high_order_kappa_h=None,
+            kappa_h=None,
             barrier_eps=barrier_eps,
             local_clf=True,
         )
@@ -809,7 +809,7 @@ class TestClfCbf(object):
             xi=xi,
             lambda_mat=lambda_mat,
             lagrangians=lagrangians,
-            high_order_kappa_h=None,
+            kappa_h=None,
             barrier_eps=barrier_eps,
             local_clf=True,
         )
@@ -885,7 +885,7 @@ class TestClfCbf(object):
             xi=xi,
             lambda_mat=lambda_mat,
             lagrangians=lagrangians,
-            high_order_kappa_h=None,
+            kappa_h=None,
             barrier_eps=barrier_eps,
             local_clf=True,
         )
@@ -1926,7 +1926,7 @@ class TestCLfCbfWHocbfs:
             xi=xi_vec,
             lambda_mat=lambda_mat,
             lagrangians=lagrangians,
-            high_order_kappa_h=self.kappa_h,
+            kappa_h=self.kappa_h,
             barrier_eps=self.barrier_eps,
             local_clf=True,
         )
@@ -2003,7 +2003,7 @@ class TestCLfCbfWHocbfs:
             xi=xi,
             lambda_mat=lambda_mat,
             lagrangians=lagrangians,
-            high_order_kappa_h=self.kappa_h,
+            kappa_h=self.kappa_h,
             barrier_eps=barrier_eps,
             local_clf=True,
         )

--- a/tests/test_clf_cbf.py
+++ b/tests/test_clf_cbf.py
@@ -81,7 +81,7 @@ class TestCompatibleStatesOptions:
             h=h,
             high_order_kappah=None,
             f=None,
-            )
+        )
         assert V_relu is not None
         assert phi_relu is None
 
@@ -169,8 +169,8 @@ class TestCompatibleStatesOptions:
             V=V,
             h=h,
             high_order_kappah=high_order_kappah,
-            f=system_drift
-            )
+            f=system_drift,
+        )
         assert V_relu is not None
         assert phi_relu is not None
         assert len(phi_relu) == h.shape[0]
@@ -211,16 +211,16 @@ class TestCompatibleStatesOptions:
                     relative_degree=dut.relative_degrees[i],
                     betas=high_order_kappah[i],
                 )
-                assert len(lower_lie_derivative_polys_i) == dut.relative_degrees[i]-1
+                assert len(lower_lie_derivative_polys_i) == dut.relative_degrees[i] - 1
                 phi_relu_expected_i = np.array(
                     [
                         np.maximum(
                             np.zeros(dut.candidate_compatible_states.shape[0]),
                             -lower_lie_derivative_polys_i[j].EvaluateIndeterminates(
                                 x, dut.candidate_compatible_states.T
-                            )
+                            ),
                         ).reshape((-1,))
-                        for j in range(dut.relative_degrees[i]-1)
+                        for j in range(dut.relative_degrees[i] - 1)
                     ]
                 )
                 phi_relu_expected.append(phi_relu_expected_i)
@@ -229,9 +229,8 @@ class TestCompatibleStatesOptions:
             np.testing.assert_allclose(result.GetSolution(h_relu), h_relu_expected)
             for i in range(len(phi_relu)):
                 np.testing.assert_allclose(
-                    result.GetSolution(phi_relu[i]),
-                    phi_relu_expected[i]
-                    )
+                    result.GetSolution(phi_relu[i]), phi_relu_expected[i]
+                )
 
             for constraints in [constraint1, constraint2, constraint3]:
                 for c in constraints:
@@ -439,12 +438,7 @@ class TestClfCbf(object):
         )
         kappa_V = 0.01
         kappa_h = np.array([0.02, 0.03])
-        xi, lambda_mat = dut._calc_xi_Lambda(
-            V=V,
-            h=h,
-            kappa_V=kappa_V,
-            kappa_h=kappa_h
-            )
+        xi, lambda_mat = dut._calc_xi_Lambda(V=V, h=h, kappa_V=kappa_V, kappa_h=kappa_h)
         assert xi.shape == (1 + dut.num_cbf,)
         assert lambda_mat.shape == (1 + dut.num_cbf, dut.nu)
         dhdx = np.empty((2, 3), dtype=object)
@@ -487,12 +481,7 @@ class TestClfCbf(object):
         )
         kappa_V = None
         kappa_h = np.array([0.02, 0.03])
-        xi, lambda_mat = dut._calc_xi_Lambda(
-            V=V,
-            h=h,
-            kappa_V=kappa_V,
-            kappa_h=kappa_h
-            )
+        xi, lambda_mat = dut._calc_xi_Lambda(V=V, h=h, kappa_V=kappa_V, kappa_h=kappa_h)
         assert xi.shape == (dut.num_cbf,)
         assert lambda_mat.shape == (dut.num_cbf, dut.nu)
         dhdx = np.empty((2, 3), dtype=object)
@@ -534,12 +523,7 @@ class TestClfCbf(object):
         )
         kappa_V = 0.01
         kappa_h = np.array([0.02, 0.03])
-        xi, lambda_mat = dut._calc_xi_Lambda(
-            V=V,
-            h=h,
-            kappa_V=kappa_V,
-            kappa_h=kappa_h
-            )
+        xi, lambda_mat = dut._calc_xi_Lambda(V=V, h=h, kappa_V=kappa_V, kappa_h=kappa_h)
 
         dVdx = V.Jacobian(self.x)
         dhdx = np.empty((2, self.nx), dtype=object)
@@ -604,8 +588,8 @@ class TestClfCbf(object):
         kappa_V = 0.01
         kappah = np.array([[0.1, 0.1], [0.1, 0.1]])
         # compute the expected Lambda and xi by hand:
-        LfV = 2*x[0]*x[1]
-        LgV = 2*x[1]
+        LfV = 2 * x[0] * x[1]
+        LgV = 2 * x[1]
         Lfh1 = -x[1]
         Lfh2 = x[1]
         Lf2h1 = 0
@@ -616,29 +600,28 @@ class TestClfCbf(object):
         beta_12 = kappah[0][1]
         beta_21 = kappah[1][0]
         beta_22 = kappah[1][1]
-        lambda_mat_expected = np.array([
-            [sym.Polynomial(-LgLfh1)],
-            [sym.Polynomial(-LgLfh2)],
-            [sym.Polynomial(LgV)]
-        ])
+        lambda_mat_expected = np.array(
+            [
+                [sym.Polynomial(-LgLfh1)],
+                [sym.Polynomial(-LgLfh2)],
+                [sym.Polynomial(LgV)],
+            ]
+        )
         lambda_mat_expected = np.concatenate((lambda_mat_expected, dut.Au), axis=0)
-        xi_expected = np.array([
-            sym.Polynomial(
-                Lf2h1 + (beta_11 + beta_12) * Lfh1 + (beta_11*beta_12) * h[0]
+        xi_expected = np.array(
+            [
+                sym.Polynomial(
+                    Lf2h1 + (beta_11 + beta_12) * Lfh1 + (beta_11 * beta_12) * h[0]
                 ),
-            sym.Polynomial(
-                Lf2h2 + (beta_21 + beta_22) * Lfh2 + (beta_21*beta_22) * h[1]
+                sym.Polynomial(
+                    Lf2h2 + (beta_21 + beta_22) * Lfh2 + (beta_21 * beta_22) * h[1]
                 ),
-            sym.Polynomial(-LfV - kappa_V * V),
-        ])
+                sym.Polynomial(-LfV - kappa_V * V),
+            ]
+        )
         xi_expected = np.concatenate((xi_expected, dut.bu), axis=0)
 
-        xi, lambda_mat = dut._calc_xi_Lambda(
-            V=V,
-            h=h,
-            kappa_V=kappa_V,
-            kappa_h=kappah
-        )
+        xi, lambda_mat = dut._calc_xi_Lambda(V=V, h=h, kappa_V=kappa_V, kappa_h=kappah)
 
         assert xi.shape == xi_expected.shape
         assert lambda_mat.shape == lambda_mat_expected.shape
@@ -696,7 +679,7 @@ class TestClfCbf(object):
         prog, lagrangians = dut.construct_search_compatible_lagrangians(
             V, h, kappa_V, kappa_h, lagrangian_degrees, barrier_eps
         )
-    
+
     def test_add_compatibility_w_clf_y_squared(self):
         """
         Test _add_compatibility with CLF and use_y_squared=True
@@ -748,12 +731,7 @@ class TestClfCbf(object):
             state_eq_constraints=None,
         )
 
-        xi, lambda_mat = dut._calc_xi_Lambda(
-            V=V,
-            h=h,
-            kappa_V=kappa_V,
-            kappa_h=kappa_h
-            )
+        xi, lambda_mat = dut._calc_xi_Lambda(V=V, h=h, kappa_V=kappa_V, kappa_h=kappa_h)
 
         barrier_eps = np.array([0.01, 0.02])
         poly = dut._add_compatibility(
@@ -822,12 +800,7 @@ class TestClfCbf(object):
         )
         lagrangians = lagrangian_degrees.to_lagrangians(prog, dut.x_set, dut.y_set)
 
-        xi, lambda_mat = dut._calc_xi_Lambda(
-            V=V,
-            h=h,
-            kappa_V=kappa_V,
-            kappa_h=kappa_h
-            )
+        xi, lambda_mat = dut._calc_xi_Lambda(V=V, h=h, kappa_V=kappa_V, kappa_h=kappa_h)
         barrier_eps = np.array([0.01, 0.02])
         poly = dut._add_compatibility_w_vrep(
             prog=prog,
@@ -903,12 +876,7 @@ class TestClfCbf(object):
         )
         lagrangians = lagrangian_degrees.to_lagrangians(prog, dut.x_set, dut.y_set)
 
-        xi, lambda_mat = dut._calc_xi_Lambda(
-            V=V,
-            h=h,
-            kappa_V=kappa_V,
-            kappa_h=kappa_h
-            )
+        xi, lambda_mat = dut._calc_xi_Lambda(V=V, h=h, kappa_V=kappa_V, kappa_h=kappa_h)
         barrier_eps = np.array([0.01, 0.02])
         poly = dut._add_compatibility_w_vrep(
             prog=prog,
@@ -1344,7 +1312,7 @@ class TestClfCbfToy:
             relative_degrees=None,
             weight_lower_lie_derivatives=None,
             V_margin=None,
-            h_margins=None
+            h_margins=None,
         )
         V_new, h_new, result = dut.search_clf_cbf_given_lagrangian(
             compatible_lagrangians,
@@ -1876,51 +1844,38 @@ class TestCompatibleWithU:
 
 
 class TestCLfCbfWHocbfs:
-    
+
     @classmethod
     def setup_class(cls):
         # we use a 1D double intergrator for testing
         cls.nx = 2
         cls.nu = 1
         cls.x = sym.MakeVectorContinuousVariable(cls.nx, "x")
-        cls.f = np.array([
-            sym.Polynomial(cls.x[1]),
-            sym.Polynomial(0)
-        ])
-        cls.g = np.array([
-            [sym.Polynomial(0)], 
-            [sym.Polynomial(1)]
-            ])
+        cls.f = np.array([sym.Polynomial(cls.x[1]), sym.Polynomial(0)])
+        cls.g = np.array([[sym.Polynomial(0)], [sym.Polynomial(1)]])
         cls.exclude_sets = [
-            mut.ExcludeSet(np.array([
-                sym.Polynomial(cls.x[0] + 10),
-                sym.Polynomial(-cls.x[0] + 10)
-            ]))
+            mut.ExcludeSet(
+                np.array(
+                    [sym.Polynomial(cls.x[0] + 10), sym.Polynomial(-cls.x[0] + 10)]
+                )
+            )
         ]
         cls.within_set = None
-        
+
         _, S = controller.LinearQuadraticRegulator(
-            A = np.array([
-                [0, 1],
-                [0, 0]
-                ]),
-            B = np.array([[0], [1]]),
-            Q = np.eye(2),
-            R = np.eye(1),
+            A=np.array([[0, 1], [0, 0]]),
+            B=np.array([[0], [1]]),
+            Q=np.eye(2),
+            R=np.eye(1),
         )
         cls.V = sym.Polynomial(np.dot(cls.x, np.dot(S, cls.x)))
-        cls.h = np.array([
-            sym.Polynomial(cls.x[0] + 5),
-            sym.Polynomial(-cls.x[0] + 5)
-        ])
+        cls.h = np.array([sym.Polynomial(cls.x[0] + 5), sym.Polynomial(-cls.x[0] + 5)])
 
         cls.kappa_V = 0.1
-        cls.kappa_h = np.array([
-            [1, 1], [1, 1]
-        ])
+        cls.kappa_h = np.array([[1, 1], [1, 1]])
         cls.relative_degrees = [2, 2]
         cls.barrier_eps = np.array([0.01, 0.01])
-    
+
     def test_add_compatibility_w_hocbf(self):
         dut = mut.CompatibleClfCbf(
             f=self.f,
@@ -1949,14 +1904,12 @@ class TestCLfCbfWHocbfs:
             lower_lie_derivative=[
                 [mut.XYDegree(x=2, y=2)],
                 [mut.XYDegree(x=2, y=2)],
-                ],
+            ],
             state_eq_constraints=None,
         )
 
-        lagrangians =lagrangian_degrees.to_lagrangians(
-            prog=prog,
-            x=dut.x_set,
-            y=dut.y_set
+        lagrangians = lagrangian_degrees.to_lagrangians(
+            prog=prog, x=dut.x_set, y=dut.y_set
         )
 
         xi_vec, lambda_mat = dut._calc_xi_Lambda(
@@ -1983,23 +1936,23 @@ class TestCLfCbfWHocbfs:
             vector_field=self.f,
             variables=self.x,
             relative_degree=self.relative_degrees[0],
-            betas=self.kappa_h[0]
+            betas=self.kappa_h[0],
         )
         lower_lie_derivative_polys_h1 = utils.lower_lie_derivatives(
             poly=self.h[1],
             vector_field=self.f,
             variables=self.x,
             relative_degree=self.relative_degrees[1],
-            betas=self.kappa_h[1]
+            betas=self.kappa_h[1],
         )
         expected_poly = (
-            -1 
-            -np.dot(lagrangians.lambda_y, np.dot(lambda_mat.T, dut.y_squared_poly))
-            -lagrangians.xi_y * (xi_vec.dot(dut.y_squared_poly) + 1)
-            -lagrangians.rho_minus_V * (1 - self.V)
-            -lagrangians.h_plus_eps.dot(self.h + self.barrier_eps)
-            -lagrangians.lower_lie_derivative[0].dot(lower_lie_derivative_polys_h0)
-            -lagrangians.lower_lie_derivative[1].dot(lower_lie_derivative_polys_h1)
+            -1
+            - np.dot(lagrangians.lambda_y, np.dot(lambda_mat.T, dut.y_squared_poly))
+            - lagrangians.xi_y * (xi_vec.dot(dut.y_squared_poly) + 1)
+            - lagrangians.rho_minus_V * (1 - self.V)
+            - lagrangians.h_plus_eps.dot(self.h + self.barrier_eps)
+            - lagrangians.lower_lie_derivative[0].dot(lower_lie_derivative_polys_h0)
+            - lagrangians.lower_lie_derivative[1].dot(lower_lie_derivative_polys_h1)
         )
 
         assert poly.CoefficientsAlmostEqual(expected_poly, tolerance=1e-5)
@@ -2025,10 +1978,7 @@ class TestCLfCbfWHocbfs:
         prog.AddIndeterminates(dut.xy_set)
 
         lagrangian_degrees = mut.CompatibleWVrepLagrangianDegrees(
-            u_vertices=[
-                mut.XYDegree(x=2, y=2) 
-                for _ in range(dut.u_vertices.shape[0])
-                ],
+            u_vertices=[mut.XYDegree(x=2, y=2) for _ in range(dut.u_vertices.shape[0])],
             u_extreme_rays=None,
             y=None,
             y_cross=None,
@@ -2037,17 +1987,14 @@ class TestCLfCbfWHocbfs:
             lower_lie_derivative=[
                 [mut.XYDegree(x=2, y=2)],
                 [mut.XYDegree(x=2, y=2)],
-                ],
+            ],
             state_eq_constraints=None,
         )
         lagrangians = lagrangian_degrees.to_lagrangians(prog, dut.x_set, dut.y_set)
 
         xi, lambda_mat = dut._calc_xi_Lambda(
-            V=self.V,
-            h=self.h,
-            kappa_V=self.kappa_V,
-            kappa_h=self.kappa_h
-            )
+            V=self.V, h=self.h, kappa_V=self.kappa_V, kappa_h=self.kappa_h
+        )
         barrier_eps = np.array([0.01, 0.02])
         poly = dut._add_compatibility_w_vrep(
             prog=prog,
@@ -2066,20 +2013,22 @@ class TestCLfCbfWHocbfs:
             vector_field=self.f,
             variables=self.x,
             relative_degree=self.relative_degrees[0],
-            betas=self.kappa_h[0]
+            betas=self.kappa_h[0],
         )
         lower_lie_derivative_polys_h1 = utils.lower_lie_derivatives(
             poly=self.h[1],
             vector_field=self.f,
             variables=self.x,
             relative_degree=self.relative_degrees[1],
-            betas=self.kappa_h[1]
+            betas=self.kappa_h[1],
         )
 
         expected_poly = (
             -1
             - lagrangians.u_vertices.dot(
-                -xi.dot(dut.y_squared_poly) + dut.y_squared_poly @ (lambda_mat @ dut.u_vertices.T) - 1
+                -xi.dot(dut.y_squared_poly)
+                + dut.y_squared_poly @ (lambda_mat @ dut.u_vertices.T)
+                - 1
             )
             - lagrangians.rho_minus_V * (1 - self.V)
             - lagrangians.h_plus_eps.dot(self.h + barrier_eps)

--- a/tests/test_clf_cbf.py
+++ b/tests/test_clf_cbf.py
@@ -586,7 +586,7 @@ class TestClfCbf(object):
         V = sym.Polynomial(x[0] ** 2 + x[1] ** 2)
         h = np.array([sym.Polynomial(1 - x[0]), sym.Polynomial(1 + x[0])])
         kappa_V = 0.01
-        kappah = np.array([[0.1, 0.1], [0.1, 0.1]])
+        kappah = [[0.1, 0.1], [0.1, 0.1]]
         # compute the expected Lambda and xi by hand:
         LfV = 2 * x[0] * x[1]
         LgV = 2 * x[1]
@@ -741,7 +741,7 @@ class TestClfCbf(object):
             xi=xi,
             lambda_mat=lambda_mat,
             lagrangians=lagrangians,
-            kappa_h=None,
+            high_order_kappa_h=None,
             barrier_eps=barrier_eps,
             local_clf=True,
         )
@@ -809,7 +809,7 @@ class TestClfCbf(object):
             xi=xi,
             lambda_mat=lambda_mat,
             lagrangians=lagrangians,
-            kappa_h=None,
+            high_order_kappa_h=None,
             barrier_eps=barrier_eps,
             local_clf=True,
         )
@@ -885,7 +885,7 @@ class TestClfCbf(object):
             xi=xi,
             lambda_mat=lambda_mat,
             lagrangians=lagrangians,
-            kappa_h=None,
+            high_order_kappa_h=None,
             barrier_eps=barrier_eps,
             local_clf=True,
         )
@@ -1872,7 +1872,7 @@ class TestCLfCbfWHocbfs:
         cls.h = np.array([sym.Polynomial(cls.x[0] + 5), sym.Polynomial(-cls.x[0] + 5)])
 
         cls.kappa_V = 0.1
-        cls.kappa_h = np.array([[1, 1], [1, 1]])
+        cls.kappa_h = [[1, 1], [1, 1]]
         cls.relative_degrees = [2, 2]
         cls.barrier_eps = np.array([0.01, 0.01])
 
@@ -1926,7 +1926,7 @@ class TestCLfCbfWHocbfs:
             xi=xi_vec,
             lambda_mat=lambda_mat,
             lagrangians=lagrangians,
-            kappa_h=self.kappa_h,
+            high_order_kappa_h=self.kappa_h,
             barrier_eps=self.barrier_eps,
             local_clf=True,
         )
@@ -2003,7 +2003,7 @@ class TestCLfCbfWHocbfs:
             xi=xi,
             lambda_mat=lambda_mat,
             lagrangians=lagrangians,
-            kappa_h=self.kappa_h,
+            high_order_kappa_h=self.kappa_h,
             barrier_eps=barrier_eps,
             local_clf=True,
         )


### PR DESCRIPTION
Included the "lagragians times lower relative degree polynomials" term into the following functions:
 1. "_add_compatibility()"
 2. "_add_compatibility_vrep()".

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hongkai-dai/compatible_clf_cbf/88)
<!-- Reviewable:end -->
